### PR TITLE
[HOTFIX] Misspelled variable name

### DIFF
--- a/sapmon/payload/helper/tracing.py
+++ b/sapmon/payload/helper/tracing.py
@@ -66,7 +66,7 @@ class tracing:
             protocol = "https",
             queue = storageQueue.name
             )
-         queueStorageLogHandler.level = DEFAULT_QUEUE_TRACER_LEVEL
+         queueStorageLogHandler.level = DEFAULT_QUEUE_TRACE_LEVEL
          formatter = logging.Formatter(tracing.config["formatters"]["detailed"]["format"])
          queueStorageLogHandler.setFormatter(formatter)
       except Exception as e:


### PR DESCRIPTION
This PR addresses a typo for the default queue trace level variable name, which caused storage queue tracing not to be initialized properly.