### PR TITLE
Add JSON formatter to Storage Queue tracing

### DIFF
--- a/sapmon/payload/const.py
+++ b/sapmon/payload/const.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 # Version of the payload script
-PAYLOAD_VERSION = "0.7.2"
+PAYLOAD_VERSION = "0.8.0"
 
 # Default file/directory locations
 PATH_PAYLOAD       = os.path.dirname(os.path.realpath(__file__))

--- a/sapmon/payload/helper/tracing.py
+++ b/sapmon/payload/helper/tracing.py
@@ -55,7 +55,6 @@ class JsonFormatter(logging.Formatter):
 
 # Helper class to enable all kinds of tracing
 class tracing:
-   sapmonIdFilterEmpty = '"sapmonId": ""'
    config = {
        "version": 1,
        "disable_existing_loggers": True,


### PR DESCRIPTION
- This PR adds a JSON formatter to the Storage Queue and makes application tracing (and eventually, ingestion of customer metrics) much more flexible.
- The `queueStorageLogHandler` now uses by default the JsonFormatter which outputs the entire trace message as a JSON-formatted string; custom fields (like salmonid or payloadVersion) are supported as well.
- Sample KQL query:
```
SapMonitorActivity
| project message
| extend p=parse_json(message)
| extend pid=p.pid
| extend timestamp=p.timestamp
| extend traceLevel=p.traceLevel
| extend msg=p.msg
| extend module=p.module
| extend lineNum=p.lineNum
| extend function=p.function
| extend sapmonId=p.sapmonId
| extend payloadVersion=p.payloadVersion
| where sapmonId == "bbbbbbbaaaaaaa"
| order by tostring(timestamp) asc
| project-away p, message, sapmonId
| project-reorder pid, timestamp, traceLevel, msg, module, lineNum, function, payloadVersion
```