### PR TITLE
Replace pyhdb with hdbcli

### DIFF
--- a/sapmon/payload/const.py
+++ b/sapmon/payload/const.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 # Version of the payload script
-PAYLOAD_VERSION = "0.8.0"
+PAYLOAD_VERSION = "0.10.0"
 
 # Default file/directory locations
 PATH_PAYLOAD       = os.path.dirname(os.path.realpath(__file__))

--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -10,7 +10,7 @@ from provider.base import *
 from typing import Dict, List
 
 # SAP HANA modules
-import pyhdb
+from hdbcli import dbapi
 
 ###############################################################################
 
@@ -44,12 +44,11 @@ class SapHana:
 
    # Connect to a HDB instance
    def connect(self) -> None:
-      self.connection = pyhdb.Connection(host = self.host,
-                                         port = self.port,
-                                         user = self.user,
-                                         password = self.password,
-                                         timeout = self.TIMEOUT_HANA_SECS)
-      self.connection.connect()
+      self.connection = dbapi.connect(address = self.host,
+                                      port = self.port,
+                                      user = self.user,
+                                      password = self.password,
+                                      timeout = self.TIMEOUT_HANA_SECS)
       self.cursor = self.connection.cursor()
 
    # Close an open HDB connection

--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -186,3 +186,4 @@ class SapHanaCheck(SapmonCheck):
       self.state["lastResultHash"] = self.calculateResultHash()
       self.tracer.info("internal state successfully updated")
       return True
+

--- a/sapmon/setup/configureMonitorVM.sh
+++ b/sapmon/setup/configureMonitorVM.sh
@@ -32,8 +32,8 @@ ExecuteCommand "apt-get -y update"
 ExecuteCommand "apt-get install -y python3-pip"
 # Upgrade pip
 ExecuteCommand "python3 -m pip install -U pip"
-# Install pyhdb
-ExecuteCommand "pip3 install pyhdb"
+# Install hdbcli
+ExecuteCommand "pip3 install hdbcli"
 # Install azure_storage_logging
 ExecuteCommand "pip3 install azure_storage_logging"
 # Install azure-mgmt-storage


### PR DESCRIPTION
- This PR replaces the open-source [PyHDB](https://github.com/SAP/PyHDB) client our Azure Monitor for SAP Solutions payload has been using so far with SAP's official [hdbcli](https://pypi.org/project/hdbcli/).
- SAP releases their Python dbapi-based HANA client hdbcli now openly; installation via pip, no customer download of the hdbclient package is required.

Note: `PAYLOAD_VERSION` in const.py jumps from 0.8.0 to 0.10.0 as 0.9.0 should be assigned to PR #7 (donaliu/customer metrics).