### PR TITLE
[HOTFIX] Catch expired HANA license situations

### DIFF
--- a/sapmon/payload/const.py
+++ b/sapmon/payload/const.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 # Version of the payload script
-PAYLOAD_VERSION = "0.12.0"
+PAYLOAD_VERSION = "0.12.1"
 
 # Default file/directory locations
 PATH_PAYLOAD       = os.path.dirname(os.path.realpath(__file__))

--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -58,7 +58,11 @@ class SapHana:
    # Execute a SQL query
    def runQuery(self,
                 sql: str) -> (Dict[str, str], List[str]):
-      self.cursor.execute(sql)
+      try:
+         self.cursor.execute(sql)
+      except Exception as e:
+         self.tracer.error("could not execute HANA query (%s)" % e)
+         return {}, []
       colIndex = {col[0] : idx for idx, col in enumerate(self.cursor.description)}
       return colIndex, self.cursor.fetchall()
 

--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -290,7 +290,8 @@ def onboard(args: str) -> None:
    try:
       hana = SapHana(appTracer, hanaDetails = hanaDetails)
       hana.connect()
-      hana.runQuery("SELECT 0 FROM DUMMY")
+      # Below query will fail if HANA license is expired
+      hana.runQuery("SELECT * FROM M_DATABASES")
       # TODO - check for permissions on monitoring tables
       hana.disconnect()
    except Exception as e:

--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -291,7 +291,7 @@ def onboard(args: str) -> None:
       hana = SapHana(appTracer, hanaDetails = hanaDetails)
       hana.connect()
       # Below query will fail if HANA license is expired
-      hana.runQuery("SELECT * FROM M_DATABASES")
+      hana.runQuery("SELECT * FROM M_SERVICES")
       # TODO - check for permissions on monitoring tables
       hana.disconnect()
    except Exception as e:


### PR DESCRIPTION
- Problem Description: SAP HANA installations come with a limited-time trial license; after the license is expired, no SQL queries (except the ones to register a license key) can be executed.
  - **Problem 1:** The dummy query` SELECT 0 FROM DUMMY` used by the onboarding payload is actually not blocked by HANA; therefore, situations where a SAP Monitor instance is _deployed_ against  a HANA DB with an expired license are not detected.
  - **Problem 2:** The `runQuery()` method does not check for license errors returned by the pyhdb client; therefore, situations where a SAP Monitor instance is _running the monitoring payload_ against a HANA DB with an expired license are not detected.
- This PR addresses both problems on top of the 