### PR TITLE
Fixed issue where customer analytics were not getting sent to Kusto

### DIFF
--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -151,12 +151,13 @@ class _Context(object):
       return
 
    def ingestCustomerAnalytics(self,
+                               customLog: str,
                                resultJson: str) -> None:
       appTracer.info("sending customer analytics")
-      results = json.loads(resultJson, object_hook=JsonDecoder.datetimeHook)
+      results = json.loads(resultJson)
       for result in results:
          metrics = {
-            "Type": c.customLog,
+            "Type": customLog,
             "Data": result,
          }
          appTracer.debug("metrics=%s" % metrics)
@@ -250,7 +251,7 @@ def monitor(args: str) -> None:
 
          # Ingest result into Customer Analytics
          if ctx.enableCustomerAnalytics:
-            ctx.ingestCustomerAnalytics(resultJson)
+            ctx.ingestCustomerAnalytics(check.customLog, resultJson)
 
    appTracer.info("monitor payload successfully completed")
    return


### PR DESCRIPTION
Customer analytics were not getting sent to the queue.
There was a bug in the code where the `c` in `c.customLog` was undefined.
There was also another issue where `object_hook=JsonDecoder.datetimeHook` was preventing `json.dumps(metrics)` from working. Looks like the datetimeHook just transforms the datetime into an object. not sure why that is necessary since Kusto can do that. removing that for now