### PR TITLE
Switch Keyvault Access to use the python-sdk

### DIFF
--- a/Docker/master/Dockerfile
+++ b/Docker/master/Dockerfile
@@ -4,7 +4,7 @@ ARG RELEASE
 RUN apt-get -y update
 RUN apt-get install -y python3-pip git
 RUN python3 -m pip install -U pip
-RUN pip3 install pyhdb azure_storage_logging azure-mgmt-storage
+RUN pip3 install pyhdb azure_storage_logging azure-mgmt-storage azure-keyvault-secrets azure-identity
 RUN mkdir -p /var/opt/microsoft/sapmon/${RELEASE}
 RUN git clone https://github.com/Azure/AzureMonitorForSAPSolutions.git --branch ${RELEASE} ${RELEASE}
 RUN cp -a ${RELEASE}/sapmon/* /var/opt/microsoft/sapmon/${RELEASE}

--- a/sapmon/payload/helper/azure.py
+++ b/sapmon/payload/helper/azure.py
@@ -1,6 +1,8 @@
 # Azure modules
 from azure.common.credentials import BasicTokenAuthentication
 from azure.mgmt.storage import StorageManagementClient
+from azure.identity import DefaultAzureCredential
+from azure.keyvault.secrets import SecretClient
 
 # Python modules
 import base64
@@ -78,7 +80,6 @@ class AzureInstanceMetadataService:
 class AzureKeyVault:
    headers = None
    kvName = None
-   params = {"api-version": "7.0"}
    token = None
    tracer = None
    uri = None
@@ -91,43 +92,20 @@ class AzureKeyVault:
       self.tracer.info("initializing KeyVault %s" % kvName)
       self.kvName = kvName
       self.uri = "https://%s.vault.azure.net" % kvName
-      self.token = AzureInstanceMetadataService.getAuthToken(self.tracer,
-                                                             "https://vault.azure.net",
-                                                             msiClientId = msiClientId)
-      self.headers = {
-         "Authorization": "Bearer %s" % self.token,
-         "Content-Type":  "application/json"
-         }
-
-   # Easy access to KeyVault REST endpoints
-   def _sendRequest(self,
-                    endpoint: str,
-                    method: Callable = requests.get,
-                    data: Optional[bytes] = None) -> (bool, str):
-      response = REST.sendRequest(self.tracer,
-                                  endpoint,
-                                  method = method,
-                                  params = self.params,
-                                  headers = self.headers,
-                                  data = data)
-      if response and "value" in response:
-         return (True, response["value"])
-      return (False, None)
+      self.token = DefaultAzureCredential(clientId = msiClientId)
+      self.kv_client = SecretClient(vault_url=self.uri, credential = self.token)
 
    # Set a secret in the KeyVault
    def setSecret(self,
                  secretName: str,
                  secretValue: str) -> bool:
       self.tracer.info("setting KeyVault secret for secretName=%s" % secretName)
-      success = False
       try:
-         (success, response) = self._sendRequest("%s/secrets/%s" % (self.uri, secretName),
-                                                 method = requests.put,
-                                                 data   = json.dumps({"value": secretValue}))
+         self.kv_client.set_secret(secretName, secretValue)
       except Exception as e:
          self.tracer.critical("could not set KeyVault secret (%s)" % e)
          sys.exit(ERROR_SETTING_KEYVAULT_SECRET)
-      return success
+      return True
 
    # Get the current version of a specific secret in the KeyVault
    def getSecret(self,
@@ -135,7 +113,7 @@ class AzureKeyVault:
       self.tracer.info("getting KeyVault secret for secretId=%s" % secretId)
       secret = None
       try:
-         (success, secret) = self._sendRequest(secretId)
+         secret = self.kv_client.get_secret(secretName)
       except Exception as e:
          self.tracer.error("could not get KeyVault secret for secretId=%s (%s)" % (secretId, e))
       return secret
@@ -145,11 +123,9 @@ class AzureKeyVault:
       self.tracer.info("getting current KeyVault secrets")
       secrets = {}
       try:
-         (success, kvSecrets) = self._sendRequest("%s/secrets" % self.uri)
-         self.tracer.debug("kvSecrets=%s" % kvSecrets)
+         kvSecrets = self.kv_client.list_properties_of_secrets()
          for k in kvSecrets:
-            id = k["id"].split("/")[-1]
-            secrets[id] = self.getSecret(k["id"])
+            secrets[k.name] = self.kv_client.get_secret(k.name).value
       except Exception as e:
          self.tracer.error("could not get current KeyVault secrets (%s)" % e)
       return secrets
@@ -158,14 +134,14 @@ class AzureKeyVault:
    def exists(self) -> bool:
       self.tracer.info("checking if KeyVault %s exists" % self.kvName)
       try:
-         (success, response) = self._sendRequest("%s/secrets" % self.uri)
+         kvSecrets = self.kv_client.list_properties_of_secrets(max_page_size=1)
+         if kvSecrets:
+            self.tracer.info("KeyVault %s exists" % self.kvName)
+            return True
       except Exception as e:
          self.tracer.error("could not determine is KeyVault %s exists (%s)" % (self.kvName, e))
-      if success:
-         self.tracer.info("KeyVault %s exists" % self.kvName)
-      else:
-         self.tracer.info("KeyVault %s does not exist" % self.kvName)
-      return success
+      self.tracer.info("KeyVault %s does not exist" % self.kvName)
+      return False
 
 ###############################################################################
 

--- a/sapmon/setup/configureMonitorVM.sh
+++ b/sapmon/setup/configureMonitorVM.sh
@@ -38,3 +38,7 @@ ExecuteCommand "pip3 install hdbcli"
 ExecuteCommand "pip3 install azure_storage_logging"
 # Install azure-mgmt-storage
 ExecuteCommand "pip3 install azure-mgmt-storage"
+# Install azure-identity
+ExecuteCommand "pip3 install azure-identity"
+# Install azure-keyvault-secrets
+ExecuteCommand "pip3 install azure-keyvault-secrets"


### PR DESCRIPTION
The current implementation does not support paging, which limits it to
keyvaults with less than 25 secrets, using the SDK fixes this. Switching to the SDK also enabled
to use the integrated service identity client.