### PR TITLE
Provders are no longer singletons

### DIFF
--- a/sapmon/payload/provider/base.py
+++ b/sapmon/payload/provider/base.py
@@ -19,10 +19,13 @@ class SapmonContentProvider:
    checks = []
    state = {}
    secrets = {}
+   stateFileSuffix = None
 
    def __init__(self,
                 tracer: logging.Logger,
-                contentFullPath: str):
+                contentFullPath: str,
+                stateFileSuffix: str):
+      self.stateFileSuffix = stateFileSuffix
       self.readState()
 
    # Read most recent, provider-specific state from state file
@@ -32,7 +35,7 @@ class SapmonContentProvider:
 
       # Parse JSON for all check states of this provider
       try:
-         filename = os.path.join(PATH_STATE, "%s.state" % self.name)
+         filename = os.path.join(PATH_STATE, "%s-%s.state" % (self.name, self.stateFileSuffix))
          self.tracer.debug("filename=%s" % filename)
          with open(filename, "r") as file:
             data = file.read()
@@ -78,12 +81,12 @@ class SapmonContentProvider:
 
       # Write JSON object into state file
       try:
-         filename = os.path.join(PATH_STATE, "%s.state" % self.name)
+         filename = os.path.join(PATH_STATE, "%s-%s.state" % (self.name, self.stateFileSuffix))
          self.tracer.debug("filename=%s" % filename)
          with open(filename, "w") as file:
             json.dump(jsonData, file, indent=3, cls=JsonEncoder)
       except Exception as e:
-         self.tracer.error("could not write state file %s (%s)" % (FILENAME_STATEFILE, e))
+         self.tracer.error("could not write state file %s (%s)" % (filename, e))
          return False
 
       self.tracer.info("successfully wrote state file for content provider %s" % self.name)

--- a/sapmon/payload/provider/base.py
+++ b/sapmon/payload/provider/base.py
@@ -18,6 +18,7 @@ class SapmonContentProvider:
    version = None
    checks = []
    state = {}
+   secrets = {}
 
    def __init__(self,
                 tracer: logging.Logger,

--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -22,9 +22,10 @@ class SapHanaProvider(SapmonContentProvider):
                 **kwargs):
       self.tracer = tracer
       self.secrets = secrets
+      stateFileSuffix = self.secrets["HanaHostname"]
       if not self.initContent(contentFullPath):
          return None
-      super().__init__(tracer, contentFullPath, **kwargs)
+      super().__init__(tracer, contentFullPath, stateFileSuffix, **kwargs)
 
    # Read content from provider definition
    # TODO(tniek): Refactor this into the generic provider class
@@ -119,7 +120,7 @@ class SapHanaCheck(SapmonCheck):
       if "hostConfig" not in self.provider.state:
          # Host config has not been retrieved yet; our only candidate is the one provided by user
          self.tracer.debug("no host config has been persisted to provider yet, using user-provided host")
-         hostsToTry = [self.secrets["HanaHostname"]]
+         hostsToTry = [self.hanaConfig["HanaHostname"]]
       else:
          # Host config has already been retrieved; rank the hosts to compile a list of hosts to try
          self.tracer.debug("host config has been persisted to provider, deriving prioritized host list")


### PR DESCRIPTION
This PR is based off of this other PR: https://github.com/Azure/AzureMonitorForSAPSolutions/pull/23
Each instance will have there own instance of a provider (IE: 2 HANA instance connections means there will be 2 instances of SapHanaProvider)
This change is in preparation for multi-instance.