### PR TITLE
Donaliu/mulipleinstances

### DIFF
--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -67,7 +67,7 @@ class SapHanaProvider(SapmonContentProvider):
    # Static method called by the onboarding payload to validate the HANA connection
    @staticmethod
    def validate(tracer, hanaConfig) -> bool:
-      tracer.info("connecting to HANA instance to run test query")
+      tracer.info("connecting to HANA instance to run test query. Hostname: %s" % hanaConfig["HanaHostname"])
 
       # Try to establish a HANA connection using the details provided by the user
       try:

--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -15,7 +15,6 @@ import os
 import re
 import sys
 import threading
-import time
 
 # Payload modules
 from const import *
@@ -197,7 +196,7 @@ def onboard(args: str) -> None:
          "EnableCustomerAnalytics":     args.EnableCustomerAnalytics,
          }])
    else:
-      # https://stackoverflow.com/questions/18006161/how-to-pass-dictionary-as-command-line-argument-to-python-script
+      # validate it is actual JSON
       jsonObj = json.loads(args.HanaDbConfigurationJson)
       hanaSecretValue = json.dumps(jsonObj)
    appTracer.info("storing HANA credentials as KeyVault secret")


### PR DESCRIPTION
This PR is based off of this other PR: https://github.com/Azure/AzureMonitorForSAPSolutions/pull/24
New argument for `onboard` called `HanaDbConfigurationJson` which will accept a JSON list of HANA configurations.
sapmon.py will monitor all the HANA instances listed in the HANA configurations each in its own thread.

Each type of provide will have it's own entry in KeyVault. Each entry will have a list of configurations for the provider to use. For every single configuration, a corresponding provider will be created and used.