### PR TITLE
[BUG FIX] Customer metrics were not getting sent

### DIFF
--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -113,6 +113,7 @@ class _Context(object):
             except Exception as e:
                appTracer.critical("could not fetch HANA password (instance=%s) from KeyVault (%s)" % (hanaDetails["HanaHostname"], e))
                sys.exit(ERROR_GETTING_HANA_CREDENTIALS)
+         ctx.enableCustomerAnalytics = hanaDetail["EnableCustomerAnalytics"]
          self.providerSecrets.append(hanaDetail)
 
       # Also extract Log Analytics credentials from secrets

--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -113,6 +113,8 @@ class _Context(object):
             except Exception as e:
                appTracer.critical("could not fetch HANA password (instance=%s) from KeyVault (%s)" % (hanaDetails["HanaHostname"], e))
                sys.exit(ERROR_GETTING_HANA_CREDENTIALS)
+         # Only the last hanaDetail will take affect, but all the EnableCustomerAnalytics flags should be the same
+         # as they are set by HANA RP. TODO: donaliu Refactor out common configs out of hanaDetails
          ctx.enableCustomerAnalytics = hanaDetail["EnableCustomerAnalytics"]
          self.providerSecrets.append(hanaDetail)
 


### PR DESCRIPTION
`ctx.enableCustomerAnalytics` was not getting set correctly so no customer metrics were getting sent.
From the code, it looks like only the last `hanaDetail` is going to write to `ctx.enableCustomerAnalytics`, however, in reality, all the `hanaDetails` should have the same flag set. (these are set by HANA RP)