### PR TITLE
Fix dockerfile to include gcc and libffi-dev

### DIFF
--- a/Docker/v1.6/Dockerfile
+++ b/Docker/v1.6/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.4-slim
 ARG RELEASE
 RUN apt-get update -y
 RUN apt-get upgrade -y
-RUN apt-get install git -y
+RUN apt-get install git gcc libffi-dev -y
 RUN pip3 install hdbcli azure_storage_logging azure-mgmt-storage
 RUN mkdir -p /var/opt/microsoft/sapmon/${RELEASE}
 RUN git clone https://github.com/Azure/AzureMonitorForSAPSolutions.git --branch ${RELEASE} ${RELEASE}


### PR DESCRIPTION
Problem:
We have to upgrade packages before we make the images. The current python-slim base image has started pulling some version of setup-tools during upgrade that requires gcc and libffi-dev. 
Solution:
install the missing packages
testing:
docker image builds fine. Tested by making sure the python version is still 3.4 otherwise hdbcli installation will not go through:

```
syaziz@persia-dev2020:~/AzureMonitorForSAPSolutions/Docker/v1.6$ docker run sapmon1 python --version
Python 3.4.10
syaziz@persia-dev2020:~/AzureMonitorForSAPSolutions/Docker/v1.6$
```