### PR TITLE
White-list metrics that are included in Customer Analytics

### DIFF
--- a/sapmon/content/saphana.json
+++ b/sapmon/content/saphana.json
@@ -6,6 +6,7 @@
             "description": "SAP HANA Host Config",
             "customLog": "SapHana_HostConfig",
             "frequencySecs": 60,
+            "includeInCustomerAnalytics": true,
             "actions": [  
                 {  
                     "type": "ExecuteSql",
@@ -23,6 +24,7 @@
             "description": "SAP HANA Load History",
             "customLog": "SapHana_LoadHistory",
             "frequencySecs": 60,
+            "includeInCustomerAnalytics": true,
             "actions": [  
                 {  
                     "type": "ExecuteSql",
@@ -39,6 +41,7 @@
             "description": "SAP HANA System Availability",
             "customLog": "SapHana_SystemAvailability",
             "frequencySecs": 60,
+            "includeInCustomerAnalytics": true,
             "actions": [  
                 {  
                     "type": "ExecuteSql",
@@ -55,6 +58,7 @@
             "description": "Probe for SAP HANA SQL connection",
             "customLog": "SapHana_SqlProbe",
             "frequencySecs": 60,
+            "includeInCustomerAnalytics": true,
             "actions": [  
                 {  
                     "type": "ProbeSqlConnection",

--- a/sapmon/payload/provider/base.py
+++ b/sapmon/payload/provider/base.py
@@ -176,6 +176,7 @@ class ProviderCheck(ABC):
    description = None
    customLog = None
    frequencySecs = None
+   includeInCustomerAnalytics = False
    actions = []
    state = {}
    fullName = None
@@ -189,12 +190,14 @@ class ProviderCheck(ABC):
                 customLog: str,
                 frequencySecs: int,
                 actions: List[str],
+                includeInCustomerAnalytics: bool = False,
                 enabled: bool = True):
       self.providerInstance = providerInstance
       self.name = name
       self.description = description
       self.customLog = customLog
       self.frequencySecs = frequencySecs
+      self.includeInCustomerAnalytics = includeInCustomerAnalytics
       self.actions = actions
       self.state = {
          "isEnabled": enabled,

--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -57,7 +57,7 @@ class ProviderInstanceThread(threading.Thread):
 
          # Ingest result into Customer Analytics
          enableCustomerAnalytics = ctx.globalParams.get("enableCustomerAnalytics", True)
-         if enableCustomerAnalytics:
+         if enableCustomerAnalytics and check.includeInCustomerAnalytics:
              tracing.ingestCustomerAnalytics(tracer,
                                              ctx,
                                              check.customLog,


### PR DESCRIPTION
- As of now, any metric collected by a provider instances is shared with Microsoft, assuming the customer has given their consent.
- This PR introduces a flag `includeInCustomerAnalytics` on provider check-level that explicitly white-lists metrics to be shared with Microsoft via Customer Analytics. This ensures no PII (which, however, might be useful for the customer to have in their own Log Analytics workspace) is shared accidentally.
- For all existing (SAP HANA) checks, which have already undergone a review, their metrics are white-listed via this flag.