### PR TITLE
Factory pattern for provider creation

### DIFF
--- a/sapmon/payload/const.py
+++ b/sapmon/payload/const.py
@@ -25,8 +25,6 @@ DEFAULT_QUEUE_TRACE_LEVEL   = logging.DEBUG
 
 # Config parameters
 CONFIG_SECTION_GLOBAL = "global"
-CLASSNAME_PROVIDER    = "%sProviderInstance"
-CLASSNAME_CHECK       = "%sProviderCheck"
 METHODNAME_ACTION     = "_action%s"
 KV_SECRET_FORMAT      = "%s-%s"
 

--- a/sapmon/payload/helper/providerfactory.py
+++ b/sapmon/payload/helper/providerfactory.py
@@ -1,0 +1,32 @@
+import logging
+import sys
+
+#from provider.base import ProviderInstance, ProviderCheck
+from provider.saphana import *
+
+availableProviders = {
+                        "saphana": (saphanaProviderInstance, saphanaProviderCheck)
+                     }
+
+class ProviderFactory(object):
+   @staticmethod
+   def makeProviderInstance(providerType: str,
+                            tracer: logging.Logger,
+                            instanceProperties: Dict[str, str],
+                            **kwargs) -> ProviderInstance:
+      if providerType in availableProviders:
+         providerClass = availableProviders[providerType][0]
+         return providerClass(tracer,
+                              instanceProperties,
+                              **kwargs)
+      raise ValueError("unknown provider type %s" % providerType)
+
+   @staticmethod
+   def makeProviderCheck(providerType: str,
+                         providerInstance: ProviderInstance,
+                         **kwargs) -> ProviderCheck:
+      if providerType in availableProviders:
+         checkClass = availableProviders[providerType][1]
+         return checkClass(providerInstance,
+                           **kwargs)
+      raise ValueError("unknown provider type %s" % providerType)

--- a/sapmon/payload/helper/providerfactory.py
+++ b/sapmon/payload/helper/providerfactory.py
@@ -1,7 +1,6 @@
 import logging
 import sys
 
-#from provider.base import ProviderInstance, ProviderCheck
 from provider.saphana import *
 
 availableProviders = {


### PR DESCRIPTION
- Rather than dynamically putting together the classname for provider instances and checks (the "evil `eval()` method"), this PR introduces a proper factory pattern for their creation.
- Going forward, only the `availableProviders` dictionary in helper/providerfactory.py needs to be extended when new providers are added.