### PR TITLE
Re-factor provider instance/check base classes

### DIFF
--- a/sapmon/payload/provider/base.py
+++ b/sapmon/payload/provider/base.py
@@ -282,5 +282,5 @@ class ProviderCheck(ABC):
 
    # Method that gets called when the internal state is updated
    @abstractmethod
-   def _updateState(self):
+   def updateState(self):
       pass

--- a/sapmon/payload/provider/base.py
+++ b/sapmon/payload/provider/base.py
@@ -246,39 +246,10 @@ class ProviderCheck(ABC):
                                                                                              methodName))
       return self.generateJsonString()
 
-   # Generate a JSON-encoded string with the last query result
-   # This string will be ingested into Log Analytics and Customer Analytics
+   # Method to generate a JSON object that can be ingested into Log Analytics
+   @abstractmethod
    def generateJsonString(self) -> str:
-      self.tracer.info("[%s] converting SQL query result set into JSON format" % self.fullName)
-      logData = []
-      
-      # Only loop through the result if there is one
-      if self.lastResult:
-         (colIndex, resultRows) = self.lastResult
-         # Iterate through all rows of the last query result
-         for r in resultRows:
-            logItem = {
-               "CONTENT_VERSION": self.providerInstance.contentVersion,
-               "SAPMON_VERSION": PAYLOAD_VERSION,
-               "PROVIDER_INSTANCE": self.providerInstance.name,
-            }
-            for c in colIndex.keys():
-               # Unless it's the column mapped to TimeGenerated, remove internal fields
-               if c != self.colTimeGenerated and (c.startswith("_") or c == "DUMMY"):
-                  continue
-               logItem[c] = r[colIndex[c]]
-            logData.append(logItem)
-
-      # Convert temporary dictionary into JSON string
-      try:
-         resultJsonString = json.dumps(logData, sort_keys=True, indent=4, cls=JsonEncoder)
-         self.tracer.debug("[%s] resultJson=%s" % (self.fullName,
-                                                   str(resultJsonString)))
-      except Exception as e:
-         self.tracer.error("[%s] could not format logItem=%s into JSON (%s)" % (self.fullName,
-                                                                                logItem,
-                                                                                e))
-      return resultJsonString
+      return
 
    # Method that gets called when the internal state is updated
    @abstractmethod

--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -243,6 +243,40 @@ class saphanaProviderCheck(ProviderCheck):
                                                                           e))
       return resultHash
 
+   # Generate a JSON-encoded string with the last query result
+   # This string will be ingested into Log Analytics and Customer Analytics
+   def generateJsonString(self) -> str:
+      self.tracer.info("[%s] converting SQL query result set into JSON format" % self.fullName)
+      logData = []
+
+      # Only loop through the result if there is one
+      if self.lastResult:
+         (colIndex, resultRows) = self.lastResult
+         # Iterate through all rows of the last query result
+         for r in resultRows:
+            logItem = {
+               "CONTENT_VERSION": self.providerInstance.contentVersion,
+               "SAPMON_VERSION": PAYLOAD_VERSION,
+               "PROVIDER_INSTANCE": self.providerInstance.name,
+            }
+            for c in colIndex.keys():
+               # Unless it's the column mapped to TimeGenerated, remove internal fields
+               if c != self.colTimeGenerated and (c.startswith("_") or c == "DUMMY"):
+                  continue
+               logItem[c] = r[colIndex[c]]
+            logData.append(logItem)
+
+      # Convert temporary dictionary into JSON string
+      try:
+         resultJsonString = json.dumps(logData, sort_keys=True, indent=4, cls=JsonEncoder)
+         self.tracer.debug("[%s] resultJson=%s" % (self.fullName,
+                                                   str(resultJsonString)))
+      except Exception as e:
+         self.tracer.error("[%s] could not format logItem=%s into JSON (%s)" % (self.fullName,
+                                                                                logItem,
+                                                                                e))
+      return resultJsonString
+
    # Update the internal state of this check (including last run times)
    def updateState(self) -> bool:
       self.tracer.info("[%s] updating internal state" % self.fullName)

--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -244,7 +244,7 @@ class saphanaProviderCheck(ProviderCheck):
       return resultHash
 
    # Update the internal state of this check (including last run times)
-   def _updateState(self) -> bool:
+   def updateState(self) -> bool:
       self.tracer.info("[%s] updating internal state" % self.fullName)
       (colIndex, resultRows) = self.lastResult
 
@@ -308,7 +308,7 @@ class saphanaProviderCheck(ProviderCheck):
                                                             resultRows))
 
       # Update internal state
-      if not self._updateState():
+      if not self.updateState():
          return False
 
       # Disconnect from HANA server to avoid memory leaks
@@ -437,6 +437,6 @@ class saphanaProviderCheck(ProviderCheck):
          )
 
       # Update internal state
-      if not self._updateState():
+      if not self.updateState():
          return False
       return True


### PR DESCRIPTION
- In previous versions, `ProviderCheck.generateJsonString()` had a very HANA-specific implementation.
- In this re-factoring PR, the method was made abstract (such that every provider type has to implement their own logic) and the HANA-specific logic moved to the `saphanaCheck` class.