### PR TITLE
Fix wrong variable name in sapmon.addProvider()

### DIFF
--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -148,7 +148,7 @@ def onboard(args: str) -> None:
          tracer.error("invalid JSON format for provider instance list (%s)" % e)
       for p in providerInstances:
          tracer.debug("trying to add provider instance %s" % p)
-         if not addProvider(providerInstance = p):
+         if not addProvider(instanceProperties = p):
             error = True
       if error:
          tracer.error("onboarding failed with errors")


### PR DESCRIPTION
- PR #36 renamed the variable `providerInstance` to `instanceProperties` in `sapmon.addProvider`.
- In the calling method `sapmon.onboard()`, the old name for this positional argument was still used; this PR addresses this.