### PR TITLE
Update Dockerfile for v2.0 to include prometheus client

### DIFF
--- a/Docker/v2.0/Dockerfile
+++ b/Docker/v2.0/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get upgrade -y
 RUN apt-get install git -y
 RUN apt-get install git gcc libffi-dev -y
 RUN pip3 install --upgrade pip
-RUN pip3 install hdbcli azure_storage_logging azure-mgmt-storage azure-keyvault-secrets azure-identity
+RUN pip3 install hdbcli azure_storage_logging azure-mgmt-storage azure-keyvault-secrets azure-identity prometheus_client
 RUN mkdir -p /var/opt/microsoft/sapmon/${RELEASE}
 RUN git clone https://github.com/Azure/AzureMonitorForSAPSolutions.git --branch ${RELEASE} ${RELEASE}
 RUN cp -a ${RELEASE}/* /var/opt/microsoft/sapmon/${RELEASE}


### PR DESCRIPTION
Problem
Prometheus client is required for the collector VM to be able to fetch metrics. 
Solution:
add it to the Docker file
Test:
A beta version of the image has been created in MCR. Testing will be done on prod