### PR TITLE
Fixed external KeyVault access using SecretClient

### DIFF
--- a/sapmon/payload/helper/azure.py
+++ b/sapmon/payload/helper/azure.py
@@ -1,7 +1,7 @@
 # Azure modules
 from azure.common.credentials import BasicTokenAuthentication
 from azure.mgmt.storage import StorageManagementClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import ManagedIdentityCredential
 from azure.keyvault.secrets import SecretClient
 
 # Python modules
@@ -92,7 +92,7 @@ class AzureKeyVault:
       self.tracer.info("initializing KeyVault %s" % kvName)
       self.kvName = kvName
       self.uri = "https://%s.vault.azure.net" % kvName
-      self.token = DefaultAzureCredential(clientId = msiClientId)
+      self.token = ManagedIdentityCredential(client_id = msiClientId)
       self.kv_client = SecretClient(vault_url=self.uri, credential = self.token)
 
    # Set a secret in the KeyVault

--- a/sapmon/payload/helper/azure.py
+++ b/sapmon/payload/helper/azure.py
@@ -120,11 +120,13 @@ class AzureKeyVault:
 
    # Get the current version of a specific secret in the KeyVault
    def getSecret(self,
-                 secretId: str) -> bool:
+                 secretId: str,
+                 version: Optional[str] = None) -> bool:
       self.tracer.info("getting KeyVault secret for secretId=%s" % secretId)
       secret = None
       try:
-         secret = self.kv_client.get_secret(secretId)
+         secret = self.kv_client.get_secret(secretId,
+                                            version)
       except Exception as e:
          self.tracer.error("could not get KeyVault secret for secretId=%s (%s)" % (secretId, e))
       return secret

--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -7,6 +7,7 @@ import time
 
 # Payload modules
 from const import *
+from helper.azure import *
 from helper.tools import *
 from provider.base import ProviderInstance, ProviderCheck
 from typing import Dict, List
@@ -69,7 +70,7 @@ class saphanaProviderInstance(ProviderInstance):
             vaultNameSearch = re.search("https://(.*).vault.azure.net", hanaDbPasswordKeyVaultUrl)
             kvName = vaultNameSearch.group(1)
          except Exception as e:
-            self.tracer.error("[%s] invalid URL for the separate KeyVault" % self.fullName)
+            self.tracer.error("[%s] invalid URL for the separate KeyVault (%s)" % (self.fullName, e))
             return False
 
          # Create temporary KeyVault object to fetch relevant secret
@@ -84,7 +85,8 @@ class saphanaProviderInstance(ProviderInstance):
          self.tracer.debug("[%s] kv=%s" % (self.fullName,
                                            kv))
          try:
-            self.hanaDbPassword = kv.getSecret(hanaDbPasswordKeyVaultUrl)
+            # TODO: proper (provider-independent) handling of external KeyVaults
+            self.hanaDbPassword = kv.getSecret("HanaDbPassword").value
          except Exception as e:
             self.tracer.error("[%s] error accessing the secret inside the separate KeyVault (%s)" % (self.fullName,
                                                                                                      e))

--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -91,7 +91,7 @@ class saphanaProviderInstance(ProviderInstance):
          # Access the actual secret from the external KeyVault
          # TODO: proper (provider-independent) handling of external KeyVaults
          try:
-            self.hanaDbPassword = kv.getSecret(passwordName, None).value#passwordVersion).value
+            self.hanaDbPassword = kv.getSecret(passwordName, None).value
          except Exception as e:
             self.tracer.error("[%s] error accessing the secret inside the separate KeyVault (%s)" % (self.fullName,
                                                                                                      e))

--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -69,8 +69,11 @@ class saphanaProviderInstance(ProviderInstance):
          try:
             vaultNameSearch = re.search("https://(.*).vault.azure.net", hanaDbPasswordKeyVaultUrl)
             kvName = vaultNameSearch.group(1)
+            passwordSearch = re.search("https://.*.vault.azure.net/secrets/(.*)/(.*)", hanaDbPasswordKeyVaultUrl)
+            passwordName = passwordSearch.group(1)
+            passwordVersion = passwordSearch.group(2)
          except Exception as e:
-            self.tracer.error("[%s] invalid URL for the separate KeyVault (%s)" % (self.fullName, e))
+            self.tracer.error("[%s] invalid URL format (%s)" % (self.fullName, e))
             return False
 
          # Create temporary KeyVault object to fetch relevant secret
@@ -82,11 +85,11 @@ class saphanaProviderInstance(ProviderInstance):
             self.tracer.error("[%s] error accessing the separate KeyVault (%s)" % (self.fullName,
                                                                                    e))
             return False
-         self.tracer.debug("[%s] kv=%s" % (self.fullName,
-                                           kv))
+
+         # Access the actual secret from the external KeyVault
+         # TODO: proper (provider-independent) handling of external KeyVaults
          try:
-            # TODO: proper (provider-independent) handling of external KeyVaults
-            self.hanaDbPassword = kv.getSecret("HanaDbPassword").value
+            self.hanaDbPassword = kv.getSecret(passwordName, passwordVersion).value
          except Exception as e:
             self.tracer.error("[%s] error accessing the secret inside the separate KeyVault (%s)" % (self.fullName,
                                                                                                      e))


### PR DESCRIPTION
Fixed three bugs which prevented external KV from working properly:
- **`DefaultAzureCredential` was the wrong class - should be `ManagedIdentityCredential`** instead
   If there is more than one MSI assigned to a VM (which is the case if a user specifies an external KV), DefaultAzureCredential will pick the first identity, which obviously returns the wrong token.
- **The correct way to pass a client ID is via `client_id`, not `clientID`**
  The [documentation](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/identity/azure-identity) was not very clear about this; I've submitted a [PR](https://github.com/Azure/azure-sdk-for-python/pull/10667) extending the examples section.
- **The secret name should be `HanaDbSecret`, not the KV URL** 
   Probably an oversight due to earlier re-factoring of the SAP HANA monitoring provider.