### PR TITLE
Provider actions will now throw exceptions instead of returning booleans for terminal state

### DIFF
--- a/sapmon/payload/provider/base.py
+++ b/sapmon/payload/provider/base.py
@@ -243,9 +243,13 @@ class ProviderCheck(ABC):
          self.tracer.debug("[%s] calling action %s" % (self.fullName,
                                                        methodName))
          method = getattr(self, methodName)
-         if method(**parameters) == False:
-            self.tracer.info("[%s] error executing action %s, skipping remaining actions" % (self.fullName,
-                                                                                             methodName))
+         try :
+            method(**parameters)
+         except Exception as e:
+            self.tracer.info("[%s] error executing action %s, Exception %s, skipping remaining actions" % (self.fullName,
+                                                                                                           e,
+                                                                                                           methodName))
+            break
       return self.generateJsonString()
 
    # Method to generate a JSON object that can be ingested into Log Analytics

--- a/sapmon/payload/provider/base.py
+++ b/sapmon/payload/provider/base.py
@@ -246,9 +246,9 @@ class ProviderCheck(ABC):
          try :
             method(**parameters)
          except Exception as e:
-            self.tracer.info("[%s] error executing action %s, Exception %s, skipping remaining actions" % (self.fullName,
-                                                                                                           e,
-                                                                                                           methodName))
+            self.tracer.error("[%s] error executing action %s, Exception %s, skipping remaining actions" % (self.fullName,
+                                                                                                            e,
+                                                                                                            methodName))
             break
       return self.generateJsonString()
 

--- a/sapmon/payload/provider/prometheus.py
+++ b/sapmon/payload/provider/prometheus.py
@@ -71,7 +71,7 @@ class prometheusProviderCheck(ProviderCheck):
         return super().__init__(provider, **kwargs)
 
     def _actionFetchMetrics(self,
-                            includePrefixes: str):
+                            includePrefixes: str) -> None:
         self.tracer.info("[%s] Fetching metrics" % self.fullName)
         metricsData = self.providerInstance.fetch_metrics()
         self.lastResult = (metricsData, includePrefixes)

--- a/sapmon/payload/provider/prometheus.py
+++ b/sapmon/payload/provider/prometheus.py
@@ -71,14 +71,14 @@ class prometheusProviderCheck(ProviderCheck):
         return super().__init__(provider, **kwargs)
 
     def _actionFetchMetrics(self,
-                            includePrefixes: str) -> bool:
+                            includePrefixes: str):
         self.tracer.info("[%s] Fetching metrics" % self.fullName)
         metricsData = self.providerInstance.fetch_metrics()
         self.lastResult = (metricsData, includePrefixes)
         if metricsData is None:
-            self.tracer.info("[%s] Unable to fetch metrics" % self.fullName)
-            return False
-        return self.updateState()
+            raise Exception("Unable to fetch metrics")
+        if not self.updateState():
+            raise Exception("Failed to update state")
 
     # Convert last result into a JSON string (as required by Log Analytics Data Collector API)
     def generateJsonString(self) -> str:

--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -313,7 +313,7 @@ class saphanaProviderCheck(ProviderCheck):
    def _actionExecuteSql(self,
                     sql: str,
                     isTimeSeries: bool = False,
-                    initialTimespanSecs: int = 60):
+                    initialTimespanSecs: int = 60) -> None:
       self.tracer.info("[%s] connecting to HANA and executing SQL" % self.fullName)
 
       # Marking which column will be used for TimeGenerated
@@ -355,7 +355,7 @@ class saphanaProviderCheck(ProviderCheck):
       self.tracer.info("[%s] successfully ran SQL for check" % self.fullName)
 
    # Parse result of the query against M_LANDSCAPE_HOST_CONFIGURATION and store it internally
-   def _actionParseHostConfig(self):
+   def _actionParseHostConfig(self) -> None:
       self.tracer.info("[%s] parsing HANA host configuration and storing it in provider state" % self.fullName)
 
       # Iterate through the results and store a mini version in the global provider state
@@ -373,7 +373,7 @@ class saphanaProviderCheck(ProviderCheck):
 
    # Probe SQL Connection to all nodes in HANA landscape
    def _actionProbeSqlConnection(self,
-                            probeTimeout: int = None):
+                            probeTimeout: int = None) -> None:
       self.tracer.info("[%s] probing SQL connection to all HANA nodes" % self.fullName)
 
       # If no probeTimeout parameter is defined for this action, use the default


### PR DESCRIPTION
Provider actions will now throw exceptions instead of returning booleans for terminal state
This is more inclusive as it it will stop at any exception rather than detecting a boolean.
This will also be used for the future retry library.