### PR TITLE
Fix reading from state file for existing deployments

### DIFF
--- a/sapmon/payload/provider/base.py
+++ b/sapmon/payload/provider/base.py
@@ -220,7 +220,7 @@ class ProviderCheck(ABC):
       # lastRunLocal = last execution time on collector VM
       # lastRunServer (used in provider) = last execution time on (HANA) server
       self.tracer.debug("[%s] verifying if check is due to be run" % self.fullName)
-      lastRunLocal = self.state["lastRunLocal"]
+      lastRunLocal = self.state.get("lastRunLocal", None)
       self.tracer.debug("[%s] lastRunLocal=%s; frequencySecs=%d; currentLocal=%s" % (self.fullName,
                                                                                      lastRunLocal,
                                                                                      self.frequencySecs,


### PR DESCRIPTION
- This PR addresses an issue when new checks are added into an existing SAP Monitor deployment (typically, this would not happen until we have auto-update).
- Workaround (without this fix) would be to delete the state file manually, so it gets properly re-created.