### PR TITLE
Prometheus: suppress selected metrics with value==0

### DIFF
--- a/sapmon/content/PrometheusHaCluster.json
+++ b/sapmon/content/PrometheusHaCluster.json
@@ -11,7 +11,8 @@
                             {
                                 "type": "FetchMetrics",
                                 "parameters": {
-                                    "includePrefixes": "^ha_cluster_"
+                                    "includePrefixes": "^ha_cluster_",
+                                    "suppressIfZeroPrefixes": "ha_cluster_(?:pacemaker_nodes|pacemaker_resources)"
                                 }
                             }
                         ]

--- a/sapmon/content/PrometheusNode.json
+++ b/sapmon/content/PrometheusNode.json
@@ -11,7 +11,8 @@
                             {
                                 "type": "FetchMetrics",
                                 "parameters": {
-                                    "includePrefixes": "^node_"
+                                    "includePrefixes": "^node_",
+                                    "suppressIfZeroPrefixes": "node_(?:systemd_unit_state)"
                                 }
                             }
                         ]

--- a/sapmon/payload/provider/base.py
+++ b/sapmon/payload/provider/base.py
@@ -252,7 +252,7 @@ class ProviderCheck(ABC):
          backoff = action.get("backoffMulitplier", self.providerInstance.retrySettings["backoffMulitplier"])
 
          try :
-            retry_call(method, fargs=parameters, tries=tries, delay=delay, backoff=backoff, logger=self.tracer)
+            retry_call(method, fkwargs=parameters, tries=tries, delay=delay, backoff=backoff, logger=self.tracer)
          except Exception as e:
             self.tracer.error("[%s] error executing action %s, Exception %s, skipping remaining actions" % (self.fullName,
                                                                                                             e,


### PR DESCRIPTION
All metrics matching the supressIfZeroPrefixes parameter in the content definition
will be left out from the resultset in case the value is 0. This can reduce the amount of data in LA drastically.