### PR TITLE
Add SapHana_Disks custom log

### DIFF
--- a/sapmon/content/SapHana.json
+++ b/sapmon/content/SapHana.json
@@ -51,6 +51,21 @@
                 }
             ]
         },
+        {
+            "name": "Disks",
+            "description": "SAP HANA Disks",
+            "customLog": "SapHana_Disks",
+            "frequencySecs": 60,
+            "includeInCustomerAnalytics": true,
+            "actions": [
+                {
+                    "type": "ExecuteSql",
+                    "parameters": {
+                        "sql": "SELECT HOST, PATH, SUBPATH, USAGE_TYPE, USED_SIZE, TOTAL_SIZE, TOTAL_DEVICE_SIZE FROM SYS.M_DISKS"
+                    }
+                }
+            ]
+        },
         {  
             "name": "SystemAvailability",
             "description": "SAP HANA System Availability",


### PR DESCRIPTION
- The [M_DISKS](https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/2.0.04/en-US/20aef7a275191014b37acbc35b4f20a4.html) view in SAP HANA provides easy access to the different disks mounted to all nodes of a HANA instance.
- This PR enables collection from this table via a check in the SapHana monitoring content.