### PR TITLE
Fix initialTimespanSecs for time-series without join

### DIFF
--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -224,7 +224,7 @@ class saphanaProviderCheck(ProviderCheck):
          if not lastRunServer:
             self.tracer.info("[%s] time series query has never been run, applying initalTimespanSecs=%d" % \
                (self.fullName, initialTimespanSecs))
-            lastRunServerUtc = "ADD_SECONDS(NOW(), i.VALUE*(-1) - %d)" % initialTimespanSecs
+            lastRunServerUtc = "LOCALTOUTC(ADD_SECONDS(NOW(), -%d))" % initialTimespanSecs
          else:
             if not isinstance(lastRunServer, datetime):
                self.tracer.error("[%s] lastRunServer=%s could not been de-serialized into datetime object" % (self.fullName,


### PR DESCRIPTION
- PR #65 removed the unnecessary join from the LoadHistory (time-series) query on M_SYSTEM_INFORMATION to determine the local timezone offset.
- This change was only done in the content JSON, but not reflected in the prepareSql() method of the SapHana provider. In case the LoadHistory check was not executed yet, this led to an error.