### PR TITLE
HANA connections will always be made via IP, rather than hostname

### DIFF
--- a/sapmon/content/SapHana.json
+++ b/sapmon/content/SapHana.json
@@ -11,7 +11,7 @@
                 {
                     "type": "ExecuteSql",
                     "parameters": {
-                        "sql": "SELECT * FROM SYS.M_LANDSCAPE_HOST_CONFIGURATION ORDER BY HOST_ACTIVE DESC, INDEXSERVER_ACTUAL_ROLE ASC"
+                        "sql": "SELECT hi.VALUE AS IP, lhc.* FROM SYS.M_LANDSCAPE_HOST_CONFIGURATION lhc LEFT OUTER JOIN SYS.M_HOST_INFORMATION hi ON lhc.HOST=hi.HOST AND hi.KEY='net_publicname' ORDER BY HOST_ACTIVE DESC, INDEXSERVER_ACTUAL_ROLE ASC"
                     }
                 },
                 {

--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -180,7 +180,7 @@ class saphanaProviderCheck(ProviderCheck):
          # Host config has already been retrieved; rank the hosts to compile a list of hosts to try
          self.tracer.debug("[%s] host config has been persisted to provider, deriving prioritized host list" % self.fullName)
          hostConfig = self.providerInstance.state["hostConfig"]
-         hostsToTry = [h["host"] for h in hostConfig]
+         hostsToTry = [h["ip"] if h.get("ip", None) else h["host"] for h in hostConfig]
 
       # Iterate through the prioritized list of hosts to try
       cursor = None
@@ -377,6 +377,7 @@ class saphanaProviderCheck(ProviderCheck):
       for r in resultRows:
          host = {
             "host": r["HOST"],
+            "ip": r["IP"],
             "active": True if r["HOST_ACTIVE"] == "YES" else False,
             "role": r["INDEXSERVER_ACTUAL_ROLE"]
             }


### PR DESCRIPTION
- Customers generally have the option to specify HANA connection via IP or hostname. This connection is used initially to regularly pull current host configuration (via [M_LANDSCAPE_HOST_CONFIGURATION](https://help.sap.com/viewer/7c78579ce9b14a669c1f3295b0d8ca16/Cloud/en-US/20b1d83875191014b028e076c874e9d7.html)) to determine the current master to connect to.
- As host configuration identifies nodes by their hostnames, there are scenarios where future connection attempts will fail because the hostname cannot be resolved (e.g. external DNS, peered VNET etc.).
- This PR implements a stop-gap solution without the need to inject additional configuration to the collector VM. Specifically, the HostConfig check now gets the IP address as well from HANA and all connection attempts are made via IP address, rather than hostname.