### PR TITLE
"Forget" logic for host config if all nodes were unreachable

### DIFF
--- a/sapmon/payload/provider/base.py
+++ b/sapmon/payload/provider/base.py
@@ -255,8 +255,8 @@ class ProviderCheck(ABC):
             retry_call(method, fkwargs=parameters, tries=tries, delay=delay, backoff=backoff, logger=self.tracer)
          except Exception as e:
             self.tracer.error("[%s] error executing action %s, Exception %s, skipping remaining actions" % (self.fullName,
-                                                                                                            e,
-                                                                                                            methodName))
+                                                                                                            methodName,
+                                                                                                            e))
             break
       return self.generateJsonString()
 

--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -197,18 +197,35 @@ class saphanaProviderCheck(ProviderCheck):
                                                                                     host,
                                                                                     self.providerInstance.hanaDbSqlPort,
                                                                                     e))
-      if not cursor:
-         self.tracer.error("[%s] unable to connect to any HANA node (hosts to try=%s); reverting back to user config" % (self.fullName,
-                                                                                                                         hostsToTry))
-         # Give up and remove current host config; for next execution, user config will be pulled
-         # This makes sense in HA/DR scenarios where customers connected HANA provider against a load balancer vIP
-         self.providerInstance.state.pop("hostConfig")
-         # Update internal state
-         if not self.updateState():
-            raise Exception("Failed to update state")
+      # If we were able to establish a connection, we're done
+      if cursor:
+         return (connection, cursor, host)
 
-         return (None, None, None)
-      return (connection, cursor, host)
+      # Our last chance: Forget HANA's current host config and try out the original user config
+      self.tracer.error("[%s] unable to connect to any HANA node (hosts to try=%s)" % (self.fullName,
+                                                                                       hostsToTry))
+      self.tracer.info("[%s] trying with connection from user config" % self.fullName)
+      try:
+         connection = self.providerInstance._establishHanaConnectionToHost(hostname = self.providerInstance.hanaHostname)
+         if connection.isconnected():
+            cursor = connection.cursor()
+            self.tracer.info("[%s] connection %s:%d from user config worked; forgetting host config" % (self.fullName,
+                                                                                                        self.providerInstance.hanaHostname,
+                                                                                                        self.providerInstance.hanaDbSqlPort))
+            # Give up and remove current host config, so a "fresh" host config will be pulled next time
+            # This is for HA/DR scenarios where customers connected against a vIP and a failover just happened
+            self.providerInstance.state.pop("hostConfig")
+            # Update internal state
+            if not self.updateState():
+               raise Exception("Failed to update state")
+            # Return (temporary) connection from user config
+            return (connection, cursor, self.providerInstance.hanaHostname)
+      except Exception as e:
+         self.tracer.error("[%s] %s:%d from user config is also unreachable (%s)" % (self.fullName,
+                                                                                     self.providerInstance.hanaHostname,
+                                                                                     self.providerInstance.hanaDbSqlPort,
+                                                                                     e))
+      return (None, None, None)
 
    # Prepare the SQL statement based on the check-specific query
    def _prepareSql(self,
@@ -393,7 +410,7 @@ class saphanaProviderCheck(ProviderCheck):
 
    # Probe SQL Connection to all nodes in HANA landscape
    def _actionProbeSqlConnection(self,
-                            probeTimeout: int = None) -> None:
+                                 probeTimeout: int = None) -> None:
       self.tracer.info("[%s] probing SQL connection to all HANA nodes" % self.fullName)
 
       # If no probeTimeout parameter is defined for this action, use the default


### PR DESCRIPTION
- Currently, the way HANA connections work is that the user specifies the master node when adding a HANA provider; it is then used to retrieve the current host config from HANA and determine the master.
- In HA/DR scenarios where the connection is configured against a load balancer vIP, this can lead to a deadlock situation once a failover occurs (i.e. HANA provider will never be able to connect against any of the node stored in the last host config).
- This PR implements a "forget" logic that gives up on the current host config if all of the nodes from the host configuration were unreachable. With the next payload execution, it will "start from scratch" and try to connect against the IP/hostname that was provided by the user.