### PR TITLE
Remove contentType field from Prometheus content

### DIFF
--- a/sapmon/content/PrometheusGeneric.json
+++ b/sapmon/content/PrometheusGeneric.json
@@ -1,5 +1,4 @@
 {
-        "contentType": "Prometheus",
         "contentVersion": "0.1.0",
         "checks": [
                 {

--- a/sapmon/content/PrometheusHaCluster.json
+++ b/sapmon/content/PrometheusHaCluster.json
@@ -1,5 +1,4 @@
 {
-        "contentType": "Prometheus",
         "contentVersion": "0.1.0",
         "checks": [
                 {

--- a/sapmon/content/PrometheusNode.json
+++ b/sapmon/content/PrometheusNode.json
@@ -1,5 +1,4 @@
 {
-        "contentType": "Prometheus",
         "contentVersion": "0.1.0",
         "checks": [
                 {


### PR DESCRIPTION
- One backlog item is to have the content define the underlying provider types; as a preparation, Prometheus* content defined a `contentType` at the top of their JSON.
- This PR removes `contentType` from all Prometheus* content, as it is currently not implemented by the provider.