### PR TITLE
Remove CONTENT_VERSION

### DIFF
--- a/sapmon/content/MsSqlServer.json
+++ b/sapmon/content/MsSqlServer.json
@@ -1,5 +1,4 @@
 {
-	"contentVersion": "0.4.0",
 	"checks": [
 		{
 			"name": "DBConnections",

--- a/sapmon/content/PrometheusGeneric.json
+++ b/sapmon/content/PrometheusGeneric.json
@@ -1,6 +1,5 @@
 {
         "contentType": "Prometheus",
-        "contentVersion": "0.1.0",
         "checks": [
                 {
                         "name": "PrometheusGenericExporter",

--- a/sapmon/content/PrometheusHaCluster.json
+++ b/sapmon/content/PrometheusHaCluster.json
@@ -1,6 +1,5 @@
 {
         "contentType": "Prometheus",
-        "contentVersion": "0.1.0",
         "checks": [
                 {
                         "name": "PrometheusHAClusterExporter",

--- a/sapmon/content/PrometheusNode.json
+++ b/sapmon/content/PrometheusNode.json
@@ -1,6 +1,5 @@
 {
         "contentType": "Prometheus",
-        "contentVersion": "0.1.0",
         "checks": [
                 {
                         "name": "PrometheusNodeExporter",

--- a/sapmon/content/SapHana.json
+++ b/sapmon/content/SapHana.json
@@ -1,5 +1,4 @@
 {
-    "contentVersion": "0.4.0",
     "checks": [
         {
             "name": "HostConfig",

--- a/sapmon/payload/const.py
+++ b/sapmon/payload/const.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 # Version of the payload script
-PAYLOAD_VERSION = "0.14.0"
+PAYLOAD_VERSION = "2.0-beta"
 
 # Default file/directory locations
 PATH_PAYLOAD       = os.path.dirname(os.path.realpath(__file__))

--- a/sapmon/payload/provider/base.py
+++ b/sapmon/payload/provider/base.py
@@ -20,7 +20,6 @@ class ProviderInstance(ABC):
    providerType = None
    providerProperties = {}
    metadata = {}
-   contentVersion = None
    checks = []
    state = {}
    retrySettings = {}
@@ -64,12 +63,6 @@ class ProviderInstance(ABC):
          self.tracer.error("[%s] could not read content file %s (%s)" % (self.fullName,
                                                                          filename,
                                                                          e))
-         return False
-
-      self.contentVersion = jsonData.get("contentVersion", None)
-      if not self.contentVersion:
-         self.tracer.error("[%s] contentVersion not specified in content file %s" % (self.fullName,
-                                                                                     filename))
          return False
 
       # Parse and instantiate the individual checks of the provider

--- a/sapmon/payload/provider/prometheus.py
+++ b/sapmon/payload/provider/prometheus.py
@@ -180,7 +180,6 @@ class prometheusProviderCheck(ProviderCheck):
         resultSet.append(prometheusSample2Dict(
             Sample("sapmon",
                    {
-                       "CONTENT_VERSION": self.providerInstance.contentVersion,
                        "SAPMON_VERSION": PAYLOAD_VERSION,
                        "PROVIDER_INSTANCE": self.providerInstance.name
                    }, 1)))

--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -276,7 +276,6 @@ class saphanaProviderCheck(ProviderCheck):
          # Iterate through all rows of the last query result
          for r in resultRows:
             logItem = {
-               "CONTENT_VERSION": self.providerInstance.contentVersion,
                "SAPMON_VERSION": PAYLOAD_VERSION,
                "PROVIDER_INSTANCE": self.providerInstance.name,
                "METADATA": self.providerInstance.metadata

--- a/sapmon/payload/provider/sqlserver.py
+++ b/sapmon/payload/provider/sqlserver.py
@@ -155,7 +155,6 @@ class MSSQLProviderCheck(ProviderCheck):
          # Iterate through all rows of the last query result
          for r in resultRows:
             logItem = {
-               "CONTENT_VERSION": self.providerInstance.contentVersion,
                "SAPMON_VERSION": PAYLOAD_VERSION,
                "PROVIDER_INSTANCE": self.providerInstance.name,
                "METADATA": self.providerInstance.metadata


### PR DESCRIPTION
- When we started out with SAP Monitor, we maintained two separate versions (payload and content); eventually, when moving to Docker, a third (release version) was added. To avoid confusion, we shall maintain a single version going forward
- This PR removes `CONTENT_VERSION` for good from all providers and adjusts `PAYLOAD_VERSION` to be identical to the release version.
  - We could debate to remove `PAYLOAD_VERSION` as well (as it can be derived from our DB), but it is currently still used for the HTTP header injection using IMDS.