### PR TITLE
Yet another name mismatch

### DIFF
--- a/sapmon/payload/provider/sqlserver.py
+++ b/sapmon/payload/provider/sqlserver.py
@@ -63,7 +63,7 @@ class MSSQLProviderInstance(ProviderInstance):
 
    # Validate that we can establish a sql connection and run queries
    def validate(self) -> bool:
-      self.tracer.info("connecting to sql instance (%s) to run test query" % self.sqlHostname)
+      self.tracer.info("connecting to sql instance (%s) to run test query" % self.SQLHostname)
 
       # Try to establish a sql connection using the details provided by the user
       try:
@@ -72,7 +72,7 @@ class MSSQLProviderInstance(ProviderInstance):
             self.tracer.error("[%s] unable to validate connection status" % self.fullName)
             return False
       except Exception as e:
-         self.tracer.error("[%s] could not establish sql connection %s (%s)" % (self.fullName,self.sqlHostname,e))
+         self.tracer.error("[%s] could not establish sql connection %s (%s)" % (self.fullName,self.SQLHostname,e))
          return False
 
       # Try to run a query 


### PR DESCRIPTION
Another naming mismatch caused the payload code to panic.
```
Failed to create persia-sql for persia-sql-test3. Error: {
  "name": "997227f0-fe65-4abf-a4a4-4145753679b6",
  "status": "Failed",
  ......
 File \\\"/var/opt/microsoft/sapmon/master/sapmon/payload/sapmon.py\\\", line 364, in main\\n    args.func(args)\\n  File \\\"/var/opt/microsoft/sapmon/master/sapmon/payload/sapmon.py\\\", line 166, in addProvider\\n    if not newProviderInstance.validate():\\n  File \\\"/var/opt/microsoft/sapmon/master/sapmon/payload/provider/sqlserver.py\\\", line 66, in validate\\n    self.tracer.info(\\\"connecting to sql instance (%!s(MISSING)) to run test query\\\" %!s(MISSING)elf.sqlHostname)\\nAttributeError: 'MSSQLProviderInstance' object has no attribute 'sqlHostname'\\n\\\"\\r\\n\\r\\nMore information on troubleshooting is available at https://aka.ms/VMExtensionCSELinuxTroubleshoot \""
  }
 }
```