### PR TITLE
Remove external MSI ('CSI') for external KV

### DIFF
--- a/sapmon/payload/helper/providerfactory.py
+++ b/sapmon/payload/helper/providerfactory.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 
+from helper.context import *
 from provider.saphana import *
 from provider.prometheus import *
 from provider.sqlserver import *
@@ -17,11 +18,13 @@ class ProviderFactory(object):
    @staticmethod
    def makeProviderInstance(providerType: str,
                             tracer: logging.Logger,
+                            ctx: Context,
                             instanceProperties: Dict[str, str],
                             **kwargs) -> ProviderInstance:
       if providerType in availableProviders:
          providerClass = availableProviders[providerType][0]
          return providerClass(tracer,
+                              ctx,
                               instanceProperties,
                               **kwargs)
       raise ValueError("unknown provider type %s" % providerType)

--- a/sapmon/payload/provider/base.py
+++ b/sapmon/payload/provider/base.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, List, Optional
 
 # Payload modules
 from const import *
+from helper.context import *
 from helper.tools import *
 
 ###############################################################################
@@ -15,6 +16,7 @@ from helper.tools import *
 # Abstract base class for an instance of a monitoring provider
 class ProviderInstance(ABC):
    tracer = None
+   ctx = None
    name = None
    fullName = None
    providerType = None
@@ -26,11 +28,13 @@ class ProviderInstance(ABC):
    
    def __init__(self,
                 tracer: logging.Logger,
+                ctx: Context,
                 providerInstance: Dict[str, str],
                 retrySettings: Dict[str, int],
                 skipContent: bool = False):
       # This constructor gets called after the child class
       self.tracer = tracer
+      self.ctx = ctx
       self.providerProperties = providerInstance["properties"]
       self.metadata = providerInstance["metadata"]
       self.name = providerInstance["name"]

--- a/sapmon/payload/provider/prometheus.py
+++ b/sapmon/payload/provider/prometheus.py
@@ -10,6 +10,7 @@ from requests.exceptions import Timeout
 
 # Payload modules
 from const import PAYLOAD_VERSION
+from helper.context import *
 from helper.tools import JsonEncoder
 from provider.base import ProviderInstance, ProviderCheck
 from typing import Dict, List
@@ -32,6 +33,7 @@ class prometheusProviderInstance(ProviderInstance):
 
     def __init__(self,
                tracer: logging.Logger,
+               ctx: Context,
                providerInstance: Dict[str, str],
                skipContent: bool = False,
                **kwargs):
@@ -43,6 +45,7 @@ class prometheusProviderInstance(ProviderInstance):
         }
 
         super().__init__(tracer,
+                         ctx,
                          providerInstance,
                          retrySettings,
                          skipContent,

--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -8,6 +8,7 @@ import time
 # Payload modules
 from const import *
 from helper.azure import *
+from helper.context import *
 from helper.tools import *
 from provider.base import ProviderInstance, ProviderCheck
 from typing import Dict, List
@@ -40,6 +41,7 @@ class saphanaProviderInstance(ProviderInstance):
 
    def __init__(self,
                 tracer: logging.Logger,
+                ctx: Context,
                 providerInstance: Dict[str, str],
                 skipContent: bool = False,
                 **kwargs):
@@ -51,6 +53,7 @@ class saphanaProviderInstance(ProviderInstance):
       }
 
       super().__init__(tracer,
+                       ctx,
                        providerInstance,
                        retrySettings,
                        skipContent,
@@ -73,9 +76,9 @@ class saphanaProviderInstance(ProviderInstance):
       self.hanaDbPassword = self.providerProperties.get("hanaDbPassword", None)
       if not self.hanaDbPassword:
          hanaDbPasswordKeyVaultUrl = self.providerProperties.get("hanaDbPasswordKeyVaultUrl", None)
-         passwordKeyVaultMsiClientId = self.providerProperties.get("keyVaultCredentialsMsiClientID", None)
-         if not hanaDbPasswordKeyVaultUrl or not passwordKeyVaultMsiClientId:
-            self.tracer.error("[%s] if no password, hanaDbPasswordKeyVaultUrl and keyVaultCredentialsMsiClientID must be given" % self.fullName)
+         passwordKeyVaultMsiClientId = self.ctx.msiClientId
+         if not hanaDbPasswordKeyVaultUrl:
+            self.tracer.error("[%s] if no password, hanaDbPasswordKeyVaultUrl must be given" % self.fullName)
             return False
 
          # Determine URL of separate KeyVault

--- a/sapmon/payload/provider/sqlserver.py
+++ b/sapmon/payload/provider/sqlserver.py
@@ -9,6 +9,7 @@ import pyodbc
 # Payload modules
 from const import *
 from helper.azure import *
+from helper.context import *
 from helper.tools import *
 from provider.base import ProviderInstance, ProviderCheck
 from typing import Dict, List
@@ -31,6 +32,7 @@ class MSSQLProviderInstance(ProviderInstance):
 
    def __init__(self,
                 tracer: logging.Logger,
+                ctx: Context,
                 providerInstance: Dict[str, str],
                 skipContent: bool = False,
                 **kwargs):
@@ -42,6 +44,7 @@ class MSSQLProviderInstance(ProviderInstance):
       }
 
       super().__init__(tracer,
+                       ctx,
                        providerInstance,
                        retrySettings,
                        skipContent,

--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -89,6 +89,7 @@ def loadConfig() -> bool:
          try:
             providerInstance = ProviderFactory.makeProviderInstance(providerType,
                                                                     tracer,
+                                                                    ctx,
                                                                     providerProperties,
                                                                     skipContent = False)
          except Exception as e:
@@ -156,6 +157,7 @@ def addProvider(args: str = None,
    try:
       newProviderInstance = ProviderFactory.makeProviderInstance(args.type,
                                                                  tracer,
+                                                                 ctx,
                                                                  instanceProperties,
                                                                  skipContent = True)
    except Exception as e:


### PR DESCRIPTION
- With the introduction of MIMP, there is no need to create a separate MSI (we called it **c**lient-**s**ide-created **i**dentity = CSI) for accessing external KVs anymore.
- Instead, the MSI that is created during deployment of a SAP Monitor (`sapmon-msi-xxxxxxxxx`) is added to the access policy of the external KV (this is done in the authorization scope of the client in both Portal and AZ CLI).
- This PR removes the relicts of the deprecated CSI from the payload and replaces it with the MSI that is already assigned to the collector VM.
  - To make this work, it was necessary to pass-thru the ctx (Context) object to the provider instance.