### PR TITLE
When fetching storage account access key, will also try to get key from key vault as well

### DIFF
--- a/sapmon/payload/const.py
+++ b/sapmon/payload/const.py
@@ -26,6 +26,7 @@ DEFAULT_QUEUE_TRACE_LEVEL   = logging.DEBUG
 # Config parameters
 CONFIG_SECTION_GLOBAL = "-global-"
 METHODNAME_ACTION     = "_action%s"
+STORAGE_ACCESS_KEY_NAME = "storageAccessKey"
 
 # Naming conventions for generated resources
 KEYVAULT_NAMING_CONVENTION               = "sapmon-kv-%s"

--- a/sapmon/payload/helper/azure.py
+++ b/sapmon/payload/helper/azure.py
@@ -2,7 +2,7 @@
 from azure.common.credentials import BasicTokenAuthentication
 from azure.mgmt.storage import StorageManagementClient
 from azure.identity import ManagedIdentityCredential
-from azure.keyvault.secrets import SecretClient
+from azure.keyvault.secrets import SecretClient, KeyVaultSecret
 
 # Python modules
 import base64
@@ -123,7 +123,7 @@ class AzureKeyVault:
    # Get the current version of a specific secret in the KeyVault
    def getSecret(self,
                  secretId: str,
-                 version: Optional[str] = None) -> bool:
+                 version: Optional[str] = None) -> KeyVaultSecret:
       self.tracer.info("getting KeyVault secret for secretId=%s" % secretId)
       secret = None
       try:

--- a/sapmon/payload/helper/tracing.py
+++ b/sapmon/payload/helper/tracing.py
@@ -139,7 +139,7 @@ class tracing:
                                           ctx.vmInstance["subscriptionId"],
                                           ctx.vmInstance["resourceGroupName"],
                                           queueName = STORAGE_QUEUE_NAMING_CONVENTION % ctx.sapmonId)
-         storageKey = storageQueue.getAccessKey()
+         storageKey = tracing.getAccessKeys(tracer, ctx)
          queueStorageLogHandler = QueueStorageHandler(account_name=storageQueue.accountName,
                                                       account_key = storageKey,
                                                       protocol = "https",
@@ -169,7 +169,7 @@ class tracing:
                                             ctx.vmInstance["subscriptionId"],
                                             ctx.vmInstance["resourceGroupName"],
                                             CUSTOMER_METRICS_QUEUE_NAMING_CONVENTION % ctx.sapmonId)
-           storageKey = storageQueue.getAccessKey()
+           storageKey = tracing.getAccessKeys(tracer, ctx)
            customerMetricsLogHandler = QueueStorageHandler(account_name = storageQueue.accountName,
                                                            account_key = storageKey,
                                                            protocol = "https",
@@ -198,3 +198,24 @@ class tracing:
          j = json.dumps(metrics)
          ctx.analyticsTracer.debug(j)
       return
+
+   # Fetches the storage access keys from keyvault or directly from storage account
+   @staticmethod
+   def getAccessKeys(tracer: logging.Logger, ctx) -> str:
+      try :
+         tracer.info("fetching queue access keys from key vault")
+         kv = AzureKeyVault(tracer,
+                            KEYVAULT_NAMING_CONVENTION % ctx.sapmonId,
+                            ctx.msiClientId)
+         return kv.getSecret(STORAGE_ACCESS_KEY_NAME).value
+      except Exception as e:
+         tracer.warning("unable to get access keys from key vault, fetching from storage account (%s) " % e)
+
+      tracer.info("fetching queue access keys from storage account")
+      storageQueue = AzureStorageQueue(tracer,
+                                       ctx.sapmonId,
+                                       ctx.authToken,
+                                       ctx.vmInstance["subscriptionId"],
+                                       ctx.vmInstance["resourceGroupName"],
+                                       CUSTOMER_METRICS_QUEUE_NAMING_CONVENTION % ctx.sapmonId)
+      return storageQueue.getAccessKey()


### PR DESCRIPTION
Problem:
* Customer wants to deploy SapMonitor when they have blocked outgoing internet connection on their VNet
* SapMonitor needs to get the Storage Account access keys to talk to the Storage queues

Solution:
* The No-Internet setup script (not yet in repo) will upload the Storage Account access keys to customer's Key Vault
* This change will allow the tracer to get the storage keys from the KeyVault (if available) or directly from the storage account

Note:
Even though the access key will be fetch from the storage account most of the time (yes-internet scenario), if the payload is unable to fetch it, the call will time out which take >3 mins. However, failing to fetch the key from Key Vault will exit out almost immediately, so `getAccessKeys` will attempt to get the key from key vault (fail fast) first, then from the storage account.

Note 2:
Also fixed the return type for `getSecret`