### PR TITLE
Updated timezone for local timestamp to be UTC

### DIFF
--- a/sapmon/payload/provider/sapnetweaver.py
+++ b/sapmon/payload/provider/sapnetweaver.py
@@ -231,7 +231,7 @@ class sapNetweaverProviderCheck(ProviderCheck):
         return super().__init__(provider, **kwargs)
 
     def _getFormattedTimestamp(self) -> str:
-        return datetime.now().isoformat()
+        return datetime.utcnow().isoformat()
 
     def _getHosts(self) -> list:
         # Fetch last known list from storage. If storage does not have list, use provided


### PR DESCRIPTION
This change is to align with the framework's convention of sending UTC timestamps to log analytics.
This pull request does not alter any behavior. The timestamp is strictly used for reporting purposes only and not for any decision making within the provider.