### PR TITLE
Parallelizing checks/Daemonizing payload

### DIFF
--- a/Docker/master/Dockerfile
+++ b/Docker/master/Dockerfile
@@ -29,5 +29,4 @@ RUN ACCEPT_EULA=Y apt-get install msodbcsql17 -y
 RUN mkdir -p /var/opt/microsoft/sapmon/${RELEASE}
 RUN git clone https://github.com/Azure/AzureMonitorForSAPSolutions.git --branch ${RELEASE} ${RELEASE}
 RUN cp -a ${RELEASE}/* /var/opt/microsoft/sapmon/${RELEASE}
-ADD monitorapp.sh /var/opt/microsoft/sapmon/${RELEASE}/monitorapp.sh
 CMD []

--- a/Docker/master/README.md
+++ b/Docker/master/README.md
@@ -1,0 +1,8 @@
+Dockerfile to create configured images containing the data collector scripts to collect telemetry from customers SAP solutions. The scripts can be found in [Azure Monitor For SAP Solutions](https://github.com/Azure/AzureMonitorForSAPSolutions)
+
+# How to run
+
+## Monitor
+```bash
+docker run --name sapmon-ver-<version> --detach --restart always --log-opt max-size=50m --log-opt max-file=5 --network host --volume /var/opt/microsoft/sapmon/state:/var/opt/microsoft/sapmon/<version>/sapmon/state --env Version=<version> <image:tag> python3 /var/opt/microsoft/sapmon/<version>/sapmon/payload/sapmon.py monitor
+```

--- a/sapmon/payload/const.py
+++ b/sapmon/payload/const.py
@@ -12,6 +12,7 @@ PATH_CONTENT       = os.path.join(PATH_ROOT, "content")
 PATH_TRACE         = os.path.join(PATH_ROOT, "trace")
 PATH_STATE         = os.path.join(PATH_ROOT, "state")
 FILENAME_TRACE     = os.path.join(PATH_TRACE, "sapmon.trc")
+FILENAME_REFRESH   = os.path.join(PATH_STATE, "refresh")
 
 # Time formats
 TIME_FORMAT_LOG_ANALYTICS = "%a, %d %b %Y %H:%M:%S GMT"
@@ -25,9 +26,14 @@ DEFAULT_FILE_TRACE_LEVEL    = logging.INFO
 DEFAULT_QUEUE_TRACE_LEVEL   = logging.DEBUG
 
 # Config parameters
-CONFIG_SECTION_GLOBAL = "-global-"
-METHODNAME_ACTION     = "_action%s"
-STORAGE_ACCESS_KEY_NAME = "storageAccessKey"
+CONFIG_SECTION_GLOBAL     = "-global-"
+METHODNAME_ACTION         = "_action%s"
+STORAGE_ACCESS_KEY_NAME   = "storageAccessKey"
+CONFIG_REFRESH_IN_SECONDS = 86400
+
+# Parallel configurations
+NUMBER_OF_THREADS     = 10
+CHECK_WAIT_IN_SECONDS = 5
 
 # Naming conventions for generated resources
 KEYVAULT_NAMING_CONVENTION               = "sapmon-kv-%s"

--- a/sapmon/payload/helper/context.py
+++ b/sapmon/payload/helper/context.py
@@ -8,6 +8,7 @@
 #
 
 # Python modules
+from datetime import datetime
 import re
 import sys
 
@@ -25,6 +26,8 @@ class Context(object):
 
    globalParams = {}
    instances = []
+   checkLockSet = set()
+   lastConfigRefreshTime = datetime(2020, 1, 1)
 
    def __init__(self,
                 tracer,

--- a/sapmon/payload/provider/base.py
+++ b/sapmon/payload/provider/base.py
@@ -208,11 +208,13 @@ class ProviderCheck(ABC):
       self.fullName = "%s.%s" % (self.providerInstance.fullName, self.name)
       self.tracer = providerInstance.tracer
 
+   # Return check name for locking
+   def getLockName(self) -> str:
+      return "%s.%s" % (self.providerInstance.fullName, self.name)
+
    # Return if this check is enabled or not
    def isEnabled(self) -> bool:
-      self.tracer.debug("[%s] verifying if check is enabled" % self.fullName)
       if not self.state["isEnabled"]:
-         self.tracer.info("[%s] check is currently not enabled, skipping" % self.fullName)
          return False
       return True
 
@@ -220,7 +222,6 @@ class ProviderCheck(ABC):
    def isDue(self) -> bool:
       # lastRunLocal = last execution time on collector VM
       # lastRunServer (used in provider) = last execution time on (HANA) server
-      self.tracer.debug("[%s] verifying if check is due to be run" % self.fullName)
       lastRunLocal = self.state.get("lastRunLocal", None)
       self.tracer.debug("[%s] lastRunLocal=%s; frequencySecs=%d; currentLocal=%s" % (self.fullName,
                                                                                      lastRunLocal,
@@ -228,7 +229,6 @@ class ProviderCheck(ABC):
                                                                                      datetime.utcnow()))
       if lastRunLocal and \
          lastRunLocal + timedelta(seconds = self.frequencySecs) > datetime.utcnow():
-         self.tracer.info("[%s] check is not due yet, skipping" % self.fullName)
          return False
       return True
 

--- a/sapmon/payload/provider/saphana.py
+++ b/sapmon/payload/provider/saphana.py
@@ -187,7 +187,7 @@ class saphanaProviderCheck(ProviderCheck):
 
       # Iterate through the prioritized list of hosts to try
       cursor = None
-      self.tracer.debug("hostsToTry=%s" % hostsToTry)
+      self.tracer.debug("[%s] hostsToTry=%s" % (self.fullName, hostsToTry))
       for host in hostsToTry:
          try:
             connection = self.providerInstance._establishHanaConnectionToHost(hostname = host)

--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -9,11 +9,14 @@
 # Python modules
 from abc import ABC, abstractmethod
 import argparse
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 import json
 import os
 import re
 import sys
 import threading
+from time import sleep
 import traceback
 
 # Payload modules
@@ -28,40 +31,31 @@ from helper.updatefactory import *
 
 ###############################################################################
 
-class ProviderInstanceThread(threading.Thread):
-   def __init__(self, providerInstance):
-      threading.Thread.__init__(self)
-      self.providerInstance = providerInstance
+def runCheck(check):
+   global ctx, tracer
 
-   def run(self):
-      global ctx, tracer
-      for check in self.providerInstance.checks:
-         tracer.info("starting check %s" % (check.fullName))
+   try:
+      # Run all actions that are part of this check
+      resultJson = check.run()
 
-         # Skip this check if it's not enabled or not due yet
-         if (check.isEnabled() == False) or (check.isDue() == False):
-            continue
+      # Ingest result into Log Analytics
+      ctx.azLa.ingest(check.customLog,
+                        resultJson,
+                        check.colTimeGenerated)
 
-         # Run all actions that are part of this check
-         resultJson = check.run()
+      # Persist updated internal state to provider state file
+      check.providerInstance.writeState()
 
-         # Ingest result into Log Analytics
-         ctx.azLa.ingest(check.customLog,
-                         resultJson,
-                         check.colTimeGenerated)
-
-         # Persist updated internal state to provider state file
-         self.providerInstance.writeState()
-
-         # Ingest result into Customer Analytics
-         enableCustomerAnalytics = ctx.globalParams.get("enableCustomerAnalytics", True)
-         if enableCustomerAnalytics and check.includeInCustomerAnalytics:
-             tracing.ingestCustomerAnalytics(tracer,
-                                             ctx,
-                                             check.customLog,
-                                             resultJson)
-         tracer.info("finished check %s" % (check.fullName))
-      return
+      # Ingest result into Customer Analytics
+      enableCustomerAnalytics = ctx.globalParams.get("enableCustomerAnalytics", True)
+      if enableCustomerAnalytics and check.includeInCustomerAnalytics:
+            tracing.ingestCustomerAnalytics(tracer,
+                                          ctx,
+                                          check.customLog,
+                                          resultJson)
+      tracer.info("finished check %s" % (check.fullName))
+   finally:
+      ctx.checkLockSet.remove(check.getLockName())
 
 ###############################################################################
 
@@ -171,6 +165,7 @@ def addProvider(args: str = None,
    if not saveInstanceToConfig(instanceProperties):
       tracer.error("could not save provider instance %s to KeyVault" % newProviderInstance.fullName)
       sys.exit(ERROR_ADDING_PROVIDER)
+   open(FILENAME_REFRESH, "w")
    tracer.info("successfully added provider instance %s to KeyVault" % newProviderInstance.fullName)
    return True
 
@@ -200,6 +195,7 @@ def deleteProvider(args: str) -> None:
       if not ctx.azKv.deleteSecret(secretToDelete):
          tracer.error("error deleting KeyVault secret %s (already marked for deletion?)" % secretToDelete)
       else:
+         open(FILENAME_REFRESH, "w")
          tracer.info("provider %s successfully deleted from KeyVault" % secretToDelete)
    return
 
@@ -208,28 +204,62 @@ def monitor(args: str) -> None:
    global ctx, tracer
    tracer.info("starting monitor payload")
 
-   threads = []
-   if not loadConfig():
-      tracer.critical("failed to load config from KeyVault")
-      sys.exit(ERROR_LOADING_CONFIG)
-   logAnalyticsWorkspaceId = ctx.globalParams.get("logAnalyticsWorkspaceId", None)
-   logAnalyticsSharedKey = ctx.globalParams.get("logAnalyticsSharedKey", None)
-   if not logAnalyticsWorkspaceId or not logAnalyticsSharedKey:
-      tracer.critical("global config must contain logAnalyticsWorkspaceId and logAnalyticsSharedKey")
-      sys.exit(ERROR_GETTING_LOG_CREDENTIALS)
-   ctx.azLa = AzureLogAnalytics(tracer,
-                                logAnalyticsWorkspaceId,
-                                logAnalyticsSharedKey)
-   for i in ctx.instances:
-      thread = ProviderInstanceThread(i)
-      thread.start()
-      threads.append(thread)
+   pool = ThreadPoolExecutor(NUMBER_OF_THREADS)
+   allChecks = []
 
-   for t in threads:
-      t.join()
+   while True:
+      now = datetime.now()
+      secondsSinceRefresh = (now-ctx.lastConfigRefreshTime).total_seconds()
+      refresh = False
 
-   tracer.info("monitor payload successfully completed")
-   return
+      # check if config needs refresh
+      # needs refresh if 24 hours as passed or refresh file found
+      if secondsSinceRefresh > CONFIG_REFRESH_IN_SECONDS:
+         tracer.info("Config has not been refreshed in %d seconds, refreshing", secondsSinceRefresh)
+         refresh = True
+      elif os.path.isfile(FILENAME_REFRESH):
+         tracer.info("Refresh file found, refreshing")
+         refresh = True
+
+      if refresh:
+         allChecks = []
+         ctx.instances = []
+
+         if not loadConfig():
+            tracer.critical("failed to load config from KeyVault")
+            sys.exit(ERROR_LOADING_CONFIG)
+         logAnalyticsWorkspaceId = ctx.globalParams.get("logAnalyticsWorkspaceId", None)
+         logAnalyticsSharedKey = ctx.globalParams.get("logAnalyticsSharedKey", None)
+         if not logAnalyticsWorkspaceId or not logAnalyticsSharedKey:
+            tracer.critical("global config must contain logAnalyticsWorkspaceId and logAnalyticsSharedKey")
+            sys.exit(ERROR_GETTING_LOG_CREDENTIALS)
+         ctx.azLa = AzureLogAnalytics(tracer,
+                                      logAnalyticsWorkspaceId,
+                                      logAnalyticsSharedKey)
+
+         for i in ctx.instances:
+            for c in i.checks:
+               allChecks.append(c)
+
+         ctx.lastConfigRefreshTime = datetime.now()
+         if os.path.exists(FILENAME_REFRESH):
+            os.remove(FILENAME_REFRESH)
+
+      for check in allChecks:
+         if check.getLockName() in ctx.checkLockSet:
+            tracer.info("[%s] already queued/executing, skipping" % check.fullName)
+            continue
+         elif not check.isEnabled():
+            tracer.info("[%s] not enabled, skipping" % check.fullName)
+            continue
+         elif not check.isDue():
+            tracer.info("[%s] not due for execution, skipping" % check.fullName)
+            continue
+         else:
+            tracer.info("[%s] getting queued" % check.fullName)
+            ctx.checkLockSet.add(check.getLockName())
+            pool.submit(runCheck, check)
+      sleep(CHECK_WAIT_IN_SECONDS)
 
 # prepareUpdate will prepare the resources like keyvault, log analytics etc for the version passed as an argument
 # prepareUpdate needs to be run when a version upgrade requires specific update to the content of the resources


### PR DESCRIPTION
This is the Parallelizing checks/Daemonizing payload feature.
The configurations can be adjusted (IE: number of threads in pool, sleep time for each run, name of refresh file)

Already tested:
* Checks getting queued correctly
  * Tested locks preventing checks getting queued if already queued/executing
  * Tread pool only executing specified number of checks
  * Checks are not getting queued if they are not due
* Config getting loaded correctly
  * Config will not refresh till a certain amount of time has passed
  * Config will not refresh till the refresh file is found
  * Add/Remove providers

NOTE:
Need to update docker commands in the RP
* Monitor Command
  * Replace `sh  /var/opt/microsoft/sapmon/%s/monitorapp.sh %s` with `python3 /var/opt/microsoft/sapmon/%s/sapmon/payload/sapmon.py monitor`
* Add/Delete provider command
  * Add `--volume /var/opt/microsoft/sapmon/state:/var/opt/microsoft/sapmon/%s/sapmon/state`