### PR TITLE
Added ENQREP filter for SapNetweaver provider

### DIFF
--- a/sapmon/content/SapNetweaver.json
+++ b/sapmon/content/SapNetweaver.json
@@ -57,7 +57,7 @@
                     "type": "ExecuteGenericWebServiceRequest",
                     "parameters": {
                         "apiName": "GetQueueStatistic",
-                        "filterFeatures": ["MESSAGESERVER", "ENQUE"],
+                        "filterFeatures": ["MESSAGESERVER", "ENQUE", "ENQREP"],
                         "filterType": "exclude"
                     }
                 }


### PR DESCRIPTION
The GetQueueStatistic API is not supported on ENQREP instances apart from the already configured instances.