### PR TITLE
fixing issue where GetQueueStatistic metrics blocked from collection …

### DIFF
--- a/sapmon/content/SapNetweaver.json
+++ b/sapmon/content/SapNetweaver.json
@@ -57,8 +57,8 @@
                     "type": "ExecuteGenericWebServiceRequest",
                     "parameters": {
                         "apiName": "GetQueueStatistic",
-                        "filterFeatures": ["MESSAGESERVER", "ENQUE", "ENQREP"],
-                        "filterType": "exclude"
+                        "filterFeatures": ["ABAP", "J2EE", "JEE"],
+                        "filterType": "include"
                     }
                 }
             ]


### PR DESCRIPTION
…due to imprecise filtering conditions on this API.  New AMS NW Provider customer had non-standard SAP setup where they were not using an enqueue replication server setup, and instead had an ABAP application server that was also hosting ENQUE functionality.  The previous filtering was incorrectly excluding this case, so we did some research and consultation and decided to make this more explicitly filtering to exactly the instances that we want to invoke this API.