### PR TITLE
Include stack trace in Short Dump changes and do not include customer analytics for ABAPGetWPTable

### DIFF
--- a/sapmon/content/SapNetweaver.json
+++ b/sapmon/content/SapNetweaver.json
@@ -34,7 +34,7 @@
             "description": "SAP Netweaver ABAPGetWPTable",
             "customLog": "SapNetweaver_ABAPGetWPTable",
             "frequencySecs": 60,
-            "includeInCustomerAnalytics": true,
+            "includeInCustomerAnalytics": false,
             "actions": [
                 {
                     "type": "ExecuteGenericWebServiceRequest",

--- a/sapmon/payload/netweaver/rfcclient.py
+++ b/sapmon/payload/netweaver/rfcclient.py
@@ -679,15 +679,15 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             return short_dump_result
         except CommunicationError as e:
             self.tracer.error("[%s] communication error for rfc %s with hostname: %s (%s)",
-                              self.logTag, rfcName, self.sapHostName, e)
+                              self.logTag, rfcName, self.sapHostName, e, exc_info=True)
 
         except ABAPApplicationError as e:
             self.tracer.error("[%s] Error occured for rfc %s with hostname: %s (%s)",
-                              self.logTag, rfcName, self.sapHostName, e)
+                              self.logTag, rfcName, self.sapHostName, e, exc_info=True)
 
         except Exception as e:
             self.tracer.error("[%s] Error occured for rfc %s with hostname: %s (%s)",
-                              self.logTag, rfcName, self.sapHostName, e)
+                              self.logTag, rfcName, self.sapHostName, e, exc_info=True)
 
         return None
     

--- a/sapmon/payload/provider/sapnetweaver.py
+++ b/sapmon/payload/provider/sapnetweaver.py
@@ -891,10 +891,10 @@ class sapNetweaverProviderCheck(ProviderCheck):
 
         except Exception as e:
             self.tracer.error("%s exception trying to fetch SMON Analysis Run metrics for %s [%d ms], error: %s", 
-                              self.logTag, 
+                              self.logTag,
                               sapHostnameStr,
                               TimeUtils.getElapsedMilliseconds(latencyStartTime),
-                              e, 
+                              e,
                               exc_info=True)
             raise
     
@@ -939,10 +939,10 @@ class sapNetweaverProviderCheck(ProviderCheck):
 
         except Exception as e:
             self.tracer.error("%s exception trying to fetch SWNC workload metrics for %s [%d ms], error: %s",
-                              self.logTag, 
+                              self.logTag,
                               sapHostnameStr,
                               TimeUtils.getElapsedMilliseconds(latencyStartTime),
-                              e, 
+                              e,
                               exc_info=True)
             raise
     
@@ -988,10 +988,11 @@ class sapNetweaverProviderCheck(ProviderCheck):
 
         except Exception as e:
             self.tracer.error("%s exception trying to fetch short dumps workload metrics for %s [%d ms], error: %s",
-                              self.logTag, 
+                              self.logTag,
                               sapHostnameStr,
                               TimeUtils.getElapsedMilliseconds(latencyStartTime),
-                              e)
+                              e,
+                              exc_info=True)
             raise
     
     def generateJsonString(self) -> str:


### PR DESCRIPTION
Code changes for the following : 
1. Include the stack trace for the exception raised from the Short Dumps-related changes.
2. Make the includeInCustomerAnalytics flag as "False" for ABAPGetWPTable to avoid saving PII information in Kusto clusters.