### PR TITLE
Code changes to make sure empty columns appears in Log Analytics Table

### DIFF
--- a/sapmon/payload/netweaver/rfcclient.py
+++ b/sapmon/payload/netweaver/rfcclient.py
@@ -753,7 +753,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
 
         for record in records:
             # parse DATUM/TIME fields into serverTimestamp
-            record['UTC Time Stamp'] = self._datetimeFromDateAndTimeString(record['E2E_DATE'], record['E2E_TIME'])
+            record['serverTimestamp'] = self._datetimeFromDateAndTimeString(record['E2E_DATE'], record['E2E_TIME'])
 
             # parse SERVER field into hostname/SID/InstanceNr properties
             m = serverRegex.match(record['E2E_HOST'])


### PR DESCRIPTION
[Created this PR for internal review]
1. sapnetweaver.py - If a property contains a null value, the property is not included in that record in Log Analytics. To fix this problem, parsed each response received from the Soap API call to check for the "None" value and replace it with an empty string.
The following tables are parsed in this PR: GetProcessList, ABAPGetWPTable. 
The other tables GetQueueStatistic, EnqGetStatistic & GetSmonAnalysisMetrics because it mostly contains numeric values, and string values are never coming as None in these tables.

2. rfcclient.py - This is a minor update in the column name from 'UTC Time Stamp' to 'serverTimestamp' because the data is essentially not UTC.
