### PR TITLE
Code changes to make sure empty columns appears in Log Analytics Table

### DIFF
--- a/sapmon/payload/netweaver/rfcclient.py
+++ b/sapmon/payload/netweaver/rfcclient.py
@@ -753,7 +753,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
 
         for record in records:
             # parse DATUM/TIME fields into serverTimestamp
-            record['UTC Time Stamp'] = self._datetimeFromDateAndTimeString(record['E2E_DATE'], record['E2E_TIME'])
+            record['serverTimestamp'] = self._datetimeFromDateAndTimeString(record['E2E_DATE'], record['E2E_TIME'])
 
             # parse SERVER field into hostname/SID/InstanceNr properties
             m = serverRegex.match(record['E2E_HOST'])

--- a/sapmon/payload/provider/sapnetweaver.py
+++ b/sapmon/payload/provider/sapnetweaver.py
@@ -819,9 +819,9 @@ class sapNetweaverProviderCheck(ProviderCheck):
                 client = self.providerInstance.getClient(instance['hostname'], httpProtocol, port)
                 results = self.providerInstance.callSoapApi(client, apiName)
                 if(apiName == "GetProcessList"):
-                    results = self._sanitizeGetProcessList(apiName, results)
+                    results = self._sanitizeGetProcessList(results)
                 elif(apiName == "ABAPGetWPTable"):
-                    results = self._sanitizeABAPGetWPTable(apiName, results)
+                    results = self._sanitizeABAPGetWPTable(results)
             except Exception as e:
                 self.tracer.error("%s unable to call the Soap Api %s - %s://%s:%s, %s", self.logTag, apiName, httpProtocol, instance['hostname'], port, e, exc_info=True)
                 continue
@@ -868,7 +868,8 @@ class sapNetweaverProviderCheck(ProviderCheck):
     """
     Method to parse the results from ABAPGetWPTable and set the strings with None value to empty string ''
     """
-    def _sanitizeABAPGetWPTable(self, apiName, records: list) -> list:
+    def _sanitizeABAPGetWPTable(self, records: list) -> list:
+       apiName = "ABAPGetWPTable"
        processed_results = list()
        for record in records:
             processed_result = {
@@ -894,7 +895,8 @@ class sapNetweaverProviderCheck(ProviderCheck):
     """
     Method to parse the results from GetProcessList and set the strings with None value to empty string ''
     """
-    def _sanitizeGetProcessList(self, apiName, records: list) -> list:
+    def _sanitizeGetProcessList(self, records: list) -> list:
+       apiName = "GetProcessList"
        processed_results = list()
        for record in records:
             processed_result = {

--- a/sapmon/payload/provider/sapnetweaver.py
+++ b/sapmon/payload/provider/sapnetweaver.py
@@ -858,7 +858,7 @@ class sapNetweaverProviderCheck(ProviderCheck):
     """
     Method to parse the value based on the key provided and set the values with None value to empty string ''
     """
-    def _getKeyValue(dictionary, key, apiName):
+    def _getKeyValue(self, dictionary, key, apiName):
             if key not in dictionary:
                 raise ValueError("Result received for api %s does not contain key: %s"% (apiName, key))
             if(dictionary[key] == None):
@@ -898,13 +898,13 @@ class sapNetweaverProviderCheck(ProviderCheck):
        processed_results = list()
        for record in records:
             processed_result = {
-                "Action": self._getKeyValue(record, 'description', apiName),
-                "Client": self._getKeyValue(record, 'dispstatus', apiName),
-                "Cpu": self._getKeyValue(record, 'elapsedtime', apiName),
-                "Err": self._getKeyValue(record, 'name', apiName),
-                "No": self._getKeyValue(record, 'pid', apiName),
-                "Pid": self._getKeyValue(record, 'starttime', apiName),
-                "Program": self._getKeyValue(record, 'textstatus', apiName)
+                "description": self._getKeyValue(record, 'description', apiName),
+                "dispstatus": self._getKeyValue(record, 'dispstatus', apiName),
+                "elapsedtime": self._getKeyValue(record, 'elapsedtime', apiName),
+                "name": self._getKeyValue(record, 'name', apiName),
+                "pid": self._getKeyValue(record, 'pid', apiName),
+                "starttime": self._getKeyValue(record, 'starttime', apiName),
+                "textstatus": self._getKeyValue(record, 'textstatus', apiName)
             }
             processed_results.append(processed_result)
        return processed_results


### PR DESCRIPTION
sapnetweaver.py - If a property contains a null value, the property is not included in that record in Log Analytics. To fix this problem, parsed each response received from the Soap API call to check for the "None" value and replace it with an empty string.
The following tables are parsed in this PR: GetProcessList, ABAPGetWPTable.
The other tables GetQueueStatistic, EnqGetStatistic & GetSmonAnalysisMetrics because it mostly contains numeric values, and string values are never coming as None in these tables.
rfcclient.py - This is a minor update in the column name from 'UTC Time Stamp' to 'serverTimestamp' because the data is essentially not UTC.