### PR TITLE
Disk monitor frequency

### DIFF
--- a/sapmon/content/SapHana.json
+++ b/sapmon/content/SapHana.json
@@ -69,7 +69,7 @@
             "name": "Disks",
             "description": "SAP HANA Disks",
             "customLog": "SapHana_Disks",
-            "frequencySecs": 60,
+            "frequencySecs": 3600,
             "includeInCustomerAnalytics": true,
             "actions": [
                 {


### PR DESCRIPTION
The default frequency for disks data collections is once every minute which seems excessive, perhaps once an hour is better?