### PR TITLE
Mfrei/nw provider missing metric record columns

### DIFF
--- a/sapmon/payload/netweaver/rfcclient.py
+++ b/sapmon/payload/netweaver/rfcclient.py
@@ -492,7 +492,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                 record['SID'] = ''
                 record['instanceNr'] = ''
 
-            record['clientId'] = self.sapClient
+            record['client'] = self.sapClient
             record['subdomain'] = self.sapSubdomain
             record['timestamp'] = currentTimestamp
 
@@ -650,7 +650,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             record['timestamp'] = currentTimestamp
             record['serverTimestamp'] = queryWindowEnd
             record['SID'] = self.sapSid
-            record['clientId'] = self.sapClient
+            record['client'] = self.sapClient
 
     """
     make RFC call GET_DUMP_LOG and return result records
@@ -767,6 +767,6 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                 record['SID'] = ''
                 record['instanceNr'] = ''
 
-            record['clientId'] = self.sapClient
+            record['client'] = self.sapClient
             record['subdomain'] = self.sapSubdomain
             record['timestamp'] = currentTimestamp

--- a/sapmon/payload/netweaver/rfcclient.py
+++ b/sapmon/payload/netweaver/rfcclient.py
@@ -492,6 +492,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                 record['SID'] = ''
                 record['instanceNr'] = ''
 
+            record['clientId'] = self.sapClient
             record['subdomain'] = self.sapSubdomain
             record['timestamp'] = currentTimestamp
 
@@ -645,13 +646,11 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
         currentTimestamp = datetime.now(timezone.utc)
 
         for record in records:
+            # swnc workload metrics are aggregated across the SID, so no need to include hostname/instance/subdomain dimensions
             record['timestamp'] = currentTimestamp
             record['serverTimestamp'] = queryWindowEnd
             record['SID'] = self.sapSid
-            # swnc workload metrics are aggregated across the SID, so no need to include hostname/instance/subdomain dimensions
-            # record['hostname'] = self.sapHostName
-            # record['instanceNr'] = self.sapSysNr
-            # record['subdomain'] = self.sapSubdomain
+            record['clientId'] = self.sapClient
 
     """
     make RFC call GET_DUMP_LOG and return result records
@@ -768,5 +767,6 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                 record['SID'] = ''
                 record['instanceNr'] = ''
 
+            record['clientId'] = self.sapClient
             record['subdomain'] = self.sapSubdomain
             record['timestamp'] = currentTimestamp

--- a/sapmon/payload/provider/sapnetweaver.py
+++ b/sapmon/payload/provider/sapnetweaver.py
@@ -1089,6 +1089,9 @@ class sapNetweaverProviderCheck(ProviderCheck):
         if self.lastResult is not None and len(self.lastResult) != 0:
             for result in self.lastResult:
                 result['SAPMON_VERSION'] = PAYLOAD_VERSION
+                result['PROVIDER_INSTANCE'] = self.providerInstance.name
+                result['METADATA'] = self.providerInstance.metadata
+    
         resultJsonString = json.dumps(self.lastResult, sort_keys=True, indent=4, cls=JsonEncoder)
         self.tracer.debug("%s resultJson=%s", self.logTag, str(resultJsonString))
         return resultJsonString


### PR DESCRIPTION
fix for two missing metric record attributes for NetWeaver provider functions.  First issue is that all metrics produced by NW Provider should have PROVIDER_INSTANCE and METADATA columns, same as Hana/Sql providers.  This will unblock creation of alert templates queries by provider name.  Second issue is that all NW RFC metrics should be decorated with the SAP Client identifier that was used for that connection.  SAP Client is a data isolation concept for SAP enables multiple customers/tenants (like test/Prod) to exist in same SID but be isolated form each other.  Data that is read during RFC calls will be restricted to just that client ID, the client is effectively part of the primary key for the data along with SID.  