### PR TITLE
added RFC call changes to connect to SAP MessageServer  

### DIFF
--- a/sapmon/payload/netweaver/metricclientfactory.py
+++ b/sapmon/payload/netweaver/metricclientfactory.py
@@ -76,6 +76,7 @@ class MetricClientFactory:
                                    sapClient=kwargs.get("sapClient", None),
                                    sapUsername=kwargs.get("sapUsername", None),
                                    sapPassword=kwargs.get("sapPassword", None),
+                                   sapLogonGroup=kwargs.get("sapLogonGroup", None),
                                    sapSid=kwargs.get("sapSid", None),
                                    columnFilterList=None,
                                    serverTimeZone=kwargs.get("serverTimeZone", None))

--- a/sapmon/payload/netweaver/metricclientfactory.py
+++ b/sapmon/payload/netweaver/metricclientfactory.py
@@ -80,7 +80,6 @@ class MetricClientFactory:
                                    sapSid=kwargs.get("sapSid", None),
                                    columnFilterList=None,
                                    serverTimeZone=kwargs.get("serverTimeZone", None))
-
         except ImportError as importEx:
             tracer.error("failed to import pyrfc module, unable to initialize NetWeaverRfcClient: ", importEx, exc_info=True)
             raise

--- a/sapmon/payload/netweaver/rfcclient.py
+++ b/sapmon/payload/netweaver/rfcclient.py
@@ -77,6 +77,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                  columnFilterList: List[str],
                  serverTimeZone: tzinfo,
                  sapSid: str,
+                 sapLogonGroup: str,
                  **kwargs) -> None:
         self.tracer = tracer
         self.logTag = logTag
@@ -89,7 +90,9 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
         self.sapUsername = sapUsername
         self.sapPassword = sapPassword
         self.columnFilterList = columnFilterList
-        self.tzinfo = serverTimeZone
+        self.tzinfo = serverTimeZone 
+        self.sapLogonGroup = sapLogonGroup
+        self.msserv = "36%s" % self.sapSysNr
 
         super().__init__(tracer, logTag)
 
@@ -175,7 +178,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
     """
     def getServerTime(self) -> datetime:
         self.tracer.info("executing RFC to get SAP server time")
-        with self._getConnection() as connection:
+        with self._getMessageServerConnection() as connection:
             # read current time from SAP NetWeaver.
             timestampResult = self._rfcGetSystemTime(connection)
             systemDateTime = self._parseSystemTimeResult(timestampResult)
@@ -192,7 +195,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                        endDateTime: datetime) -> str:
         self.tracer.info("executing RFC SDF/SMON_ANALYSIS_RUN check")
         
-        with self._getConnection() as connection:
+        with self._getMessageServerConnection() as connection:
             # get guid to call RFC SDF/SMON_ANALYSIS_READ.
             guidResult = self._rfcGetSmonRunIds(connection, startDateTime=startDateTime, endDateTime=endDateTime)
             guid = self._parseSmonRunIdsResult(guidResult)
@@ -214,7 +217,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                                startDateTime: datetime,
                                endDateTime: datetime) -> str:
         self.tracer.info("executing RFC SWNC_GET_WORKLOAD_SNAPSHOT check")
-        with self._getConnection() as connection:
+        with self._getMessageServerConnection() as connection:
             snapshotResult = self._rfcGetSwncWorkloadSnapshot(connection,
                                                               startDateTime=startDateTime, 
                                                               endDateTime=endDateTime)
@@ -234,7 +237,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                        endDateTime: datetime) -> str:
         self.tracer.info("executing RFC SDF/GET_DUMP_LOG check")
         parsedResult = None
-        with self._getConnection() as connection:
+        with self._getMessageServerConnection() as connection:
             # get guid to call RFC SDF/GET_DUMP_LOG.
             rawResult = self._rfcGetDumpLog(connection, startDateTime=startDateTime, endDateTime=endDateTime)
             if (rawResult != None) :
@@ -255,11 +258,40 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             return self.sapHostName + "." + self.sapSubdomain
         else:
             return self.sapHostName
+    """
+    establish rfc message server connection to sap.
+    """
+    def _getMessageServerConnection(self) -> Connection:
+        try:
+            # Direct application server logon:  ashost, sysnr
+            # load balancing logon:  mshost, msserv, sysid, group
+            connection = Connection(#ashost=self.fqdn, 
+                                    sysnr=self.sapSysNr, 
+                                     mshost = self.fqdn,
+                                    Group = self.sapLogonGroup,
+                                    msserv = self.msserv,
+                                    ssid = self.sapSid,
+                                    client=self.sapClient, 
+                                    user=self.sapUsername, 
+                                    passwd=self.sapPassword)
+            return connection
+        except CommunicationError as e:
+            #self.tracer.error("[%s] error establishing connection with hostname: %s, sapSysNr: %s, error: %s",
+            #                  self.logTag, self.fqdn, self.sapSysNr, e)
+            raise
+        except LogonError as e:
+            #self.tracer.error("[%s] Incorrect credentials used to connect with hostname: %s username: %s, error: %s",
+            #                  self.logTag, self.fqdn, self.sapUsername, e)
+            raise
+        except Exception as e:
+            #self.tracer.error("[%s] Error occured while establishing connection to hostname: %s, sapSysNr: %s, error: %s ",
+            #                  self.logTag, self.fqdn, self.sapSysNr, e)
+            raise
 
     """
     establish rfc  connection to sap.
     """
-    def _getConnection(self) -> Connection:
+    def _getApplicationServerConnection(self) -> Connection:
         try:
             # Direct application server logon:  ashost, sysnr
             # load balancing logon:  mshost, msserv, sysid, group

--- a/sapmon/payload/netweaver/rfcclient.py
+++ b/sapmon/payload/netweaver/rfcclient.py
@@ -92,8 +92,8 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
         self.columnFilterList = columnFilterList
         self.tzinfo = serverTimeZone 
         self.sapLogonGroup = sapLogonGroup
-        self.msserv = "36%s" % self.sapSysNr
-
+        self.msserv = "36%s" % self.sapSysNr.zfill(2)
+        
         super().__init__(tracer, logTag)
 
     #####
@@ -258,36 +258,24 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             return self.sapHostName + "." + self.sapSubdomain
         else:
             return self.sapHostName
+    
     """
     establish rfc message server connection to sap.
     """
     def _getMessageServerConnection(self) -> Connection:
-        try:
-            # Direct application server logon:  ashost, sysnr
-            # load balancing logon:  mshost, msserv, sysid, group
-            connection = Connection(#ashost=self.fqdn, 
-                                    sysnr=self.sapSysNr, 
-                                     mshost = self.fqdn,
-                                    Group = self.sapLogonGroup,
-                                    msserv = self.msserv,
-                                    ssid = self.sapSid,
-                                    client=self.sapClient, 
-                                    user=self.sapUsername, 
-                                    passwd=self.sapPassword)
-            return connection
-        except CommunicationError as e:
-            #self.tracer.error("[%s] error establishing connection with hostname: %s, sapSysNr: %s, error: %s",
-            #                  self.logTag, self.fqdn, self.sapSysNr, e)
-            raise
-        except LogonError as e:
-            #self.tracer.error("[%s] Incorrect credentials used to connect with hostname: %s username: %s, error: %s",
-            #                  self.logTag, self.fqdn, self.sapUsername, e)
-            raise
-        except Exception as e:
-            #self.tracer.error("[%s] Error occured while establishing connection to hostname: %s, sapSysNr: %s, error: %s ",
-            #                  self.logTag, self.fqdn, self.sapSysNr, e)
-            raise
-
+        # Direct application server logon:  ashost, sysnr
+        # load balancing logon:  mshost, msserv, sysid, group
+        connection = Connection(#ashost=self.fqdn, 
+                                sysnr=self.sapSysNr, 
+                                mshost=self.fqdn,
+                                Group=self.sapLogonGroup,
+                                msserv=self.msserv,
+                                ssid=self.sapSid,
+                                client=self.sapClient, 
+                                user=self.sapUsername, 
+                                passwd=self.sapPassword)
+        return connection
+            
     """
     establish rfc  connection to sap.
     """

--- a/sapmon/payload/provider/sapnetweaver.py
+++ b/sapmon/payload/provider/sapnetweaver.py
@@ -61,6 +61,7 @@ class sapNetweaverProviderInstance(ProviderInstance):
         self.sapPassword = None
         self.sapClientId = None
         self.sapRfcSdkBlobUrl = None
+        self.sapLogonGroup = None
 
         # provider instance flag for whether RFC calls should be enabled for this specific Netweaver provider instance
         self._areRfcCallsEnabled = None
@@ -115,6 +116,7 @@ class sapNetweaverProviderInstance(ProviderInstance):
         self.sapUsername = self.providerProperties.get('sapUsername', None)
         self.sapPassword = self.providerProperties.get('sapPassword', None)
         self.sapClientId = self.providerProperties.get('sapClientId', None)
+        self.sapLogonGroup = self.providerProperties.get('sapLogonGroup',None)
         self.sapRfcSdkBlobUrl = self.providerProperties.get('sapRfcSdkBlobUrl', None)
 
         # if user did not specify password directly via UI, check to see if they instead
@@ -269,12 +271,12 @@ class sapNetweaverProviderInstance(ProviderInstance):
             raise e
 
     """
-    return a netweaver RFC client initialized with the first healthy ABAP/dispatcher instance we find
-    for this SID.  If no healthy ABAP instances, this method will throw exception
+    return a netweaver RFC client initialized with "MESSAGESERVER" instance we find
+    for this SID.  
     """
     def getRfcClient(self, logTag: str) -> NetWeaverMetricClient:
         # RFC connections against direct application server instances can only be made to 'ABAP' instances
-        dispatcherInstance = self.getActiveDispatcherInstance()
+        dispatcherInstance = self.getMessageServerInstance()
 
         return MetricClientFactory.getMetricClient(tracer=self.tracer, 
                                                    logTag=logTag,
@@ -283,6 +285,7 @@ class sapNetweaverProviderInstance(ProviderInstance):
                                                    sapSubdomain=self.sapSubdomain,
                                                    sapSid=self.sapSid,
                                                    sapClient=str(self.sapClientId),
+                                                   sapLogonGroup = self.sapLogonGroup,
                                                    sapUsername=self.sapUsername,
                                                    sapPassword=self.sapPassword)
 
@@ -496,7 +499,20 @@ class sapNetweaverProviderInstance(ProviderInstance):
 
         # return first healthy instance in list
         return healthyInstances[0]
-
+    
+    """
+    fetch cached instance list for this provider and filter down to the list 'MESSAGESERVER' feature functions
+    return the available message server
+    """
+    def getMessageServerInstance(self):
+        # Use cached list of instances if available since they don't change that frequently,
+        # and filter down to only healthy dispatcher instances since RFC direct application server connection
+        # only works against dispatchera
+        dispatcherInstances = self.getInstances(filterFeatures=['MESSAGESERVER'], filterType='include', useCache=True)
+     
+        # return first healthy instance in list
+        return dispatcherInstances[0]
+    
     """
     given a list of sap instances and a set of instance features (ie. functions) to include or exclude,
     apply filtering logic and return only those instances that match the filter conditions:

--- a/sapmon/payload/provider/sapnetweaver.py
+++ b/sapmon/payload/provider/sapnetweaver.py
@@ -275,7 +275,7 @@ class sapNetweaverProviderInstance(ProviderInstance):
     for this SID.  
     """
     def getRfcClient(self, logTag: str) -> NetWeaverMetricClient:
-        # RFC connections against direct application server instances can only be made to 'ABAP' instances
+        # RFC connections against application server instances can be made through 'MESSAGESERVER' instances
         dispatcherInstance = self.getMessageServerInstance()
 
         return MetricClientFactory.getMetricClient(tracer=self.tracer, 
@@ -509,7 +509,10 @@ class sapNetweaverProviderInstance(ProviderInstance):
         # and filter down to only healthy dispatcher instances since RFC direct application server connection
         # only works against dispatchera
         dispatcherInstances = self.getInstances(filterFeatures=['MESSAGESERVER'], filterType='include', useCache=True)
-     
+        
+        if (len(dispatcherInstances) == 0):
+            raise Exception("No MESSAGESERVER instance found for %s" % self.sapSid)
+        
         # return first healthy instance in list
         return dispatcherInstances[0]
     
@@ -603,9 +606,10 @@ class sapNetweaverProviderInstance(ProviderInstance):
             if (not self.sapUsername or
                 not self.sapPassword or
                 not self.sapClientId or
-                not self.sapRfcSdkBlobUrl):
+                not self.sapRfcSdkBlobUrl or
+                not self.sapLogonGroup):
                 self.tracer.info("%s Netweaver RFC calls disabled for because missing one or more required " +
-                                 "config properties: sapUsername, sapPassword, sapClientId, and sapRfcSdkBlobUrl",
+                                 "config properties: sapUsername, sapPassword, sapClientId, sapLogonGroup and sapRfcSdkBlobUrl",
                                  self.logTag)
                 self._areRfcCallsEnabled = False
                 return False
@@ -980,7 +984,7 @@ class sapNetweaverProviderCheck(ProviderCheck):
             # track latency of entire method excecution with dependencies
             latencyStartTime = time()
             
-            # initialize a client for the first healthy ABAP/Dispatcher instance we find
+            # initialize a client for the first healthy MessageServer instance we find
             client = self.providerInstance.getRfcClient(logTag=self.logTag)
 
             # update logging prefix with the specific instance details of the client
@@ -1027,7 +1031,7 @@ class sapNetweaverProviderCheck(ProviderCheck):
             # track latency of entire method excecution with dependencies
             latencyStartTime = time()
 
-            # initialize a client for the first healthy ABAP/Dispatcher instance we find
+            # initialize a client for the first healthy MessageServer instance we find
             client = self.providerInstance.getRfcClient(logTag=self.logTag)
 
             # update logging prefix with the specific instance details of the client
@@ -1076,7 +1080,7 @@ class sapNetweaverProviderCheck(ProviderCheck):
             # track latency of entire method excecution with dependencies
             latencyStartTime = time()
 
-            # initialize a client for the first healthy ABAP/Dispatcher instance we find
+            # initialize a client for the first healthy MessageServer instance we find
             client = self.providerInstance.getRfcClient(logTag=self.logTag)
 
             # update logging prefix with the specific instance details of the client


### PR DESCRIPTION
RFC calls are made to SAP Application server through load balancer(MessageServer)-

- Earlier calls were made through ABAP feature to Application server.
- A load balancer called "MESSAGE SERVER" is added for connection from a RFC request to individual Application servers.
- A parameter "sapLogonGroup" is added so that the application type is recognized by the load balancer to route to the available  application server by the group. 
- original getConnection() method is now renamed to _getApplicationServerConnection() to fetch the ABAP instance.
- loadbalancer instance is now fetched from _getMessageServerConnection() method

Test Cases
-Ran tests to confirm SMON metrics data in dev environment
-With available logon group to see a successful RFC connection
 sapLogonGroup = "Technical"
-Passing Null value for logon group to confirm RFC connection failure
-by passing a single digit and double digits instance number 
    self.msserv = "36%s" % self.sapSysNr.zfill(2)
- checked for message server instance availibility



