### PR TITLE
ensure that heartbeat thread is signaled to shutdown ...

### DIFF
--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -214,7 +214,7 @@ def monitor(args: str) -> None:
    allChecks = []
 
    # TODO: try removing heartbeat thread completely to see if that mitigates issue with python process not exiting
-   #pool.submit(heartbeat)
+   heartbeatTask = pool.submit(heartbeat)
 
    try:
       while True:
@@ -273,7 +273,10 @@ def monitor(args: str) -> None:
    except Exception as e:
       # signal to threads we need to exit process
       isShuttingDown = True
-      pool.shutdown(wait=True)
+      tracer.info("unhandled exception in main task loop, shutting down thread executor %s", e, exc_info=True)
+      tracer.info("heartbeat task:%s, isRunning:%s, exception:%s", heartbeatTask, heartbeatTask.running, heartbeatTask.exception, exc_info=True)
+      pool.shutdown(wait=False, cancel_futures=True)
+      tracer.info("thread executor has been shutdown")
       raise
 
 # prepareUpdate will prepare the resources like keyvault, log analytics etc for the version passed as an argument

--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -213,7 +213,8 @@ def monitor(args: str) -> None:
    pool = ThreadPoolExecutor(NUMBER_OF_THREADS)
    allChecks = []
 
-   pool.submit(heartbeat)
+   # TODO: try removing heartbeat thread completely to see if that mitigates issue with python process not exiting
+   #pool.submit(heartbeat)
 
    try:
       while True:

--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -239,7 +239,6 @@ def monitor(args: str) -> None:
                tracer.critical("failed to load config from KeyVault")
                
                isShuttingDown = True
-               tracer.critical("unhandled exception in main task loop, shutting down thread executor %s", e, exc_info=True)
                tracer.critical("heartbeat task:%s, isRunning:%s, exception:%s", heartbeatTask, heartbeatTask.running, heartbeatTask.exception, exc_info=True)
                pool.shutdown(wait=True)
                tracer.critical("thread executor has been shutdown")

--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -236,12 +236,12 @@ def monitor(args: str) -> None:
 
          if not loadConfig():
             tracer.critical("failed to load config from KeyVault")
-            shutdownMonitor(ERROR_LOADING_CONFIG, pool, heartbeatTask)
+            shutdownMonitor(ERROR_LOADING_CONFIG)
          logAnalyticsWorkspaceId = ctx.globalParams.get("logAnalyticsWorkspaceId", None)
          logAnalyticsSharedKey = ctx.globalParams.get("logAnalyticsSharedKey", None)
          if not logAnalyticsWorkspaceId or not logAnalyticsSharedKey:
             tracer.critical("global config must contain logAnalyticsWorkspaceId and logAnalyticsSharedKey")
-            shutdownMonitor(ERROR_GETTING_LOG_CREDENTIALS, pool, heartbeatTask)
+            shutdownMonitor(ERROR_GETTING_LOG_CREDENTIALS)
          ctx.azLa = AzureLogAnalytics(tracer,
                                        logAnalyticsWorkspaceId,
                                        logAnalyticsSharedKey)
@@ -295,15 +295,14 @@ def ensureDirectoryStructure() -> None:
          sys.exit(ERROR_FILE_PERMISSION_DENIED)
    return
 
-def shutdownMonitor(status: object, pool: ThreadPoolExecutor, heartbeatTask: object) -> None:
+def shutdownMonitor(status: object) -> None:
    global isShuttingDown
 
    # signal to threads we need to exit process
    isShuttingDown = True
-   tracer.critical("heartbeat task:%s, isRunning:%s, exception:%s", heartbeatTask, heartbeatTask.running, heartbeatTask.exception, exc_info=True)
-   pool.shutdown(wait=True)
-   tracer.critical("thread executor has been shutdown")
-   tracer.critical("heartbeat task:%s, isRunning:%s, exception:%s", heartbeatTask, heartbeatTask.running, heartbeatTask.exception, exc_info=True)
+   tracer.critical("signaling tasks to shutdown")
+   #pool.shutdown(wait=True)
+   #tracer.critical("thread executor has been shutdown")
    sys.exit(status)
 
 def heartbeat() -> None: 

--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -272,6 +272,7 @@ def monitor(args: str) -> None:
    except Exception as e:
       # signal to threads we need to exit process
       isShuttingDown = True
+      pool.shutdown(wait=True)
       raise
 
 # prepareUpdate will prepare the resources like keyvault, log analytics etc for the version passed as an argument

--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -273,10 +273,13 @@ def monitor(args: str) -> None:
    except Exception as e:
       # signal to threads we need to exit process
       isShuttingDown = True
-      tracer.info("unhandled exception in main task loop, shutting down thread executor %s", e, exc_info=True)
-      tracer.info("heartbeat task:%s, isRunning:%s, exception:%s", heartbeatTask, heartbeatTask.running, heartbeatTask.exception, exc_info=True)
+      print("unhandled exception in main task loop, shutting down thread executor %s" % e)
+      print("heartbeat task:%s, isRunning:%s, exception:%s" % (heartbeatTask, heartbeatTask.running, heartbeatTask.exception))
+      tracer.critical("unhandled exception in main task loop, shutting down thread executor %s", e, exc_info=True)
+      tracer.critical("heartbeat task:%s, isRunning:%s, exception:%s", heartbeatTask, heartbeatTask.running, heartbeatTask.exception, exc_info=True)
       pool.shutdown(wait=False, cancel_futures=True)
-      tracer.info("thread executor has been shutdown")
+      print("thread executor has been shutdown")
+      tracer.critical("thread executor has been shutdown")
       raise
 
 # prepareUpdate will prepare the resources like keyvault, log analytics etc for the version passed as an argument

--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -207,7 +207,7 @@ def deleteProvider(args: str) -> None:
 
 # Execute the actual monitoring payload
 def monitor(args: str) -> None:
-   global ctx, tracer, isShuttingDown
+   global ctx, tracer
    tracer.info("starting monitor payload")
 
    pool = ThreadPoolExecutor(NUMBER_OF_THREADS)

--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -236,7 +236,9 @@ def monitor(args: str) -> None:
             ctx.instances = []
 
             if not loadConfig():
+               tracer.critical("heartbeat task:%s, isRunning:%s, exception:%s", heartbeatTask, heartbeatTask.running, heartbeatTask.exception, exc_info=True)
                tracer.critical("failed to load config from KeyVault")
+               tracer.critical("heartbeat task:%s, isRunning:%s, exception:%s", heartbeatTask, heartbeatTask.running, heartbeatTask.exception, exc_info=True)
                sys.exit(ERROR_LOADING_CONFIG)
             logAnalyticsWorkspaceId = ctx.globalParams.get("logAnalyticsWorkspaceId", None)
             logAnalyticsSharedKey = ctx.globalParams.get("logAnalyticsSharedKey", None)

--- a/sapmon/payload/sapmon.py
+++ b/sapmon/payload/sapmon.py
@@ -213,8 +213,7 @@ def monitor(args: str) -> None:
    pool = ThreadPoolExecutor(NUMBER_OF_THREADS)
    allChecks = []
 
-   # TODO: try removing heartbeat thread completely to see if that mitigates issue with python process not exiting
-   heartbeatTask = pool.submit(heartbeat)
+   pool.submit(heartbeat)
 
    while True:
       now = datetime.now()
@@ -243,8 +242,8 @@ def monitor(args: str) -> None:
             tracer.critical("global config must contain logAnalyticsWorkspaceId and logAnalyticsSharedKey")
             shutdownMonitor(ERROR_GETTING_LOG_CREDENTIALS)
          ctx.azLa = AzureLogAnalytics(tracer,
-                                       logAnalyticsWorkspaceId,
-                                       logAnalyticsSharedKey)
+                                      logAnalyticsWorkspaceId,
+                                      logAnalyticsSharedKey)
 
          for i in ctx.instances:
             for c in i.checks:
@@ -297,12 +296,9 @@ def ensureDirectoryStructure() -> None:
 
 def shutdownMonitor(status: object) -> None:
    global isShuttingDown
-
    # signal to threads we need to exit process
    isShuttingDown = True
    tracer.critical("signaling tasks to shutdown")
-   #pool.shutdown(wait=True)
-   #tracer.critical("thread executor has been shutdown")
    sys.exit(status)
 
 def heartbeat() -> None: 


### PR DESCRIPTION
 if main monitor loop has unhandled exception (such as if sys.exit(..) is called).  This is to fix issue where it appears that monitor container is experiencing critical exception because no key vault provider configs are defined (such as would be the case when new AMS resource created for first time), but python process is not exiting and container is not being restarted, so monitor is effectively hung.