### PR TITLE
Setup basic implementation of syslog provider

### DIFF
--- a/Docker/master/Dockerfile
+++ b/Docker/master/Dockerfile
@@ -13,6 +13,10 @@ RUN apt-get install git -y
 RUN apt-get install git gcc libffi-dev g++ unixodbc-dev -y
 RUN pip3 install --upgrade pip
 RUN pip3 install msrestazure==0.6.4 hdbcli azure-storage==0.36.0 azure_storage_logging azure-mgmt-storage==16.0.0 azure-keyvault-secrets azure-identity prometheus_client retry pyodbc pandas zeep
+RUN apt-get install rsyslog -y
+RUN apt-get install nano -y
+RUN apt-get install systemd -y
+RUN pip3 install file-read-backwards
 
 # dynamic library load path must be set to the anticipated install path of the RFC SDK libraries
 # and the directory must exist before the python process is started up.  This will allow us
@@ -25,7 +29,7 @@ ENV LD_LIBRARY_PATH=/var/opt/microsoft/sapmon/${RELEASE}/sapmon/usrlibs/nwrfcsdk
 RUN curl --location --output pynwrfc-2.3.0-cp37-cp37m-linux_x86_64.whl https://github.com/SAP/PyRFC/releases/download/2.3.0/pynwrfc-2.3.0-cp37-cp37m-linux_x86_64.whl
 RUN pip3 install pynwrfc-2.3.0-cp37-cp37m-linux_x86_64.whl
 
-RUN ACCEPT_EULA=Y apt-get install msodbcsql17 -y
+# RUN ACCEPT_EULA=Y apt-get install msodbcsql17 -y
 RUN mkdir -p /var/opt/microsoft/sapmon/${RELEASE}
 RUN git clone https://github.com/Azure/AzureMonitorForSAPSolutions.git --branch ${RELEASE} ${RELEASE}
 RUN cp -a ${RELEASE}/* /var/opt/microsoft/sapmon/${RELEASE}

--- a/sapmon/content/Syslog.json
+++ b/sapmon/content/Syslog.json
@@ -1,0 +1,16 @@
+{
+    "checks": [
+            {
+                    "name": "SyslogTest",
+                    "description": "Test",
+                    "customLog": "Syslog_Test",
+                    "includeInCustomerAnalytics": true,
+                    "frequencySecs": 15,
+                    "actions": [
+                        {
+                            "type": "FetchSyslogs"
+                        }
+                    ]
+            }
+    ]
+}

--- a/sapmon/payload/helper/providerfactory.py
+++ b/sapmon/payload/helper/providerfactory.py
@@ -6,6 +6,7 @@ from provider.saphana import *
 from provider.prometheus import *
 from provider.sqlserver import *
 from provider.sapnetweaver import *
+from provider.syslog import *
 
 availableProviders = {
                         "SapHana": (saphanaProviderInstance, saphanaProviderCheck),
@@ -14,7 +15,8 @@ availableProviders = {
                         "PrometheusHaCluster": (prometheusProviderInstance, prometheusProviderCheck),
                         "PrometheusNode": (prometheusProviderInstance, prometheusProviderCheck),
                         "PrometheusOS": (prometheusProviderInstance, prometheusProviderCheck),
-                        "SapNetweaver": (sapNetweaverProviderInstance, sapNetweaverProviderCheck)
+                        "SapNetweaver": (sapNetweaverProviderInstance, sapNetweaverProviderCheck),
+                        "Syslog": (syslogProviderInstance, syslogProviderCheck)
                      }
 
 class ProviderFactory(object):

--- a/sapmon/payload/provider/syslog.py
+++ b/sapmon/payload/provider/syslog.py
@@ -1,0 +1,108 @@
+# Python modules
+import json
+import logging
+
+# Payload modules
+from const import *
+from helper.azure import *
+from helper.context import *
+from helper.tools import *
+from provider.base import ProviderInstance, ProviderCheck
+from typing import Dict, List
+
+# Default retry settings
+RETRY_RETRIES = 1
+RETRY_DELAY_SECS = 1
+RETRY_BACKOFF_MULTIPLIER = 2
+
+###############################################################################
+
+class syslogProviderInstance(ProviderInstance):
+
+    # To store a list of hostnames that the collector VM is receiving syslogs from
+    hostnames = None
+
+    def __init__(self,
+                tracer: logging.Logger,
+                ctx: Context,
+                providerInstance: Dict[str, str],
+                skipContent: bool = False,
+                **kwargs):
+
+        retrySettings = {
+            "retries": RETRY_RETRIES,
+            "delayInSeconds": RETRY_DELAY_SECS,
+            "backoffMultiplier": RETRY_BACKOFF_MULTIPLIER
+        }
+
+        super().__init__(tracer,
+                       ctx,
+                       providerInstance,
+                       retrySettings,
+                       skipContent,
+                       **kwargs)
+
+    def validate(self) -> bool:
+        return True
+
+    # Read in hostnames from properties
+    def parseProperties(self) -> bool:
+        self.hostnames = self.providerProperties.get("hostnames", None)
+        if not self.hostnames:
+            self.tracer.error("[%s] no hostnames specified" % self.fullName)
+            return False
+        return True
+
+###############################################################################
+
+class syslogProviderCheck(ProviderCheck):
+
+    # Will store timestamp, hostname, and message of most recent syslog from each hostname
+    lastResult = []
+
+    def __init__(self,
+                provider: ProviderInstance,
+                **kwargs):
+        return super().__init__(provider, **kwargs)
+
+    # Read in syslogs from hostnames and update lastResult
+    def _actionFetchSyslogs(self):
+        for hostname in self.providerInstance.hostnames:
+            logpath = "/var/log/{}/syslog.log".format(hostname)
+            currResult = None
+            try:
+                with open(logpath, 'r') as logfile:
+                    line = logfile.readlines()[-1]
+                    split_line = line.split(" ", 2)
+                    currResult = (split_line[0], split_line[1], split_line[2])
+            except:
+                self.tracer.error("[%s] unable to read log file at: %s" % (self.fullName, logpath))
+            if currResult:
+                self.lastResult.append(currResult)
+
+    # Generate a JSON-encoded string of most recent syslog from hostnames
+    # This string will be ingested into Log Analytics and Customer Analytics
+    def generateJsonString(self) -> str:
+        logData = []
+        for result in self.lastResult:
+            logItem = {}
+            logItem["timestamp"] = result[0]
+            logItem["hostname"] = result[1]
+            logItem["message"] = result[2]
+            logData.append(logItem)
+
+        # Convert temporary dictionary into JSON string
+        try:
+            resultJsonString = json.dumps(logData, sort_keys=True, indent=4, cls=JsonEncoder)
+            self.tracer.debug("[%s] resultJson=%s" % (self.fullName,
+                                                   str(resultJsonString)))
+        except Exception as e:
+            self.tracer.error("[%s] could not format into JSON" % (self.fullName))
+
+        # Clear logs stored in lastResult
+        self.lastResult = []
+
+        return resultJsonString
+
+    def updateState(self):
+        pass

--- a/sapmon/payload/provider/syslog.py
+++ b/sapmon/payload/provider/syslog.py
@@ -28,9 +28,6 @@ TIMEDELTA_IN_DAYS = 1
 
 class syslogProviderInstance(ProviderInstance):
 
-    # To store a list of hostnames that the collector VM is receiving syslogs from
-    # hostnames = None
-
     def __init__(self,
                 tracer: logging.Logger,
                 ctx: Context,
@@ -54,19 +51,14 @@ class syslogProviderInstance(ProviderInstance):
     def validate(self) -> bool:
         return True
 
-    # Read in hostnames from properties
     def parseProperties(self) -> bool:
-        # self.hostnames = self.providerProperties.get("hostnames", None)
-        # if not self.hostnames:
-        #     self.tracer.error("[%s] no hostnames specified" % self.fullName)
-        #     return False
         return True
 
 ###############################################################################
 
 class syslogProviderCheck(ProviderCheck):
 
-    # Stores timestamp, hostname, and message of syslogs from each hostname within a certain time limit
+    # Stores timestamp, hostname, and message of syslogs from each hostname within the specified timedelta
     lastResult = []
     # Maintains state which consists of the following for each hostname:
     # - the most recent log timestamp ingested
@@ -85,7 +77,6 @@ class syslogProviderCheck(ProviderCheck):
 
     # Read in syslogs and update lastResult
     def _actionFetchSyslogs(self):
-        # for hostname in self.providerInstance.hostnames:
         for hostname in os.listdir(FORWARDED_LOGS_DIR):
             # don't fetch syslogs from docker container
             if hostname == self.container_ID:
@@ -132,7 +123,7 @@ class syslogProviderCheck(ProviderCheck):
                                 elif state_timestamp_is_none or log_line_not_ingested:
                                     # log line has not already been ingested, so safe to ingest
                                     currResult.append((timestamp, name, message))
-                                    if not lastLogDateTime or log_datetime >= lastLogDateTime:
+                                    if not lastLogDateTime or log_datetime > lastLogDateTime:
                                         lastLogDateTime = log_datetime
                                         lastMessage = message
                             else: 
@@ -170,8 +161,8 @@ class syslogProviderCheck(ProviderCheck):
             # ]
 
             resultJsonString = json.dumps(logData, sort_keys=True, indent=4, cls=JsonEncoder)
-            # self.tracer.debug("[%s] resultJson=%s" % (self.fullName,
-            #                                        str(resultJsonString)))
+            self.tracer.debug("[%s] resultJson=%s" % (self.fullName,
+                                                   str(resultJsonString)))
         except Exception as e:
             self.tracer.error("[%s] could not format into JSON" % (self.fullName))
 

--- a/sapmon/payload/provider/syslog.py
+++ b/sapmon/payload/provider/syslog.py
@@ -1,6 +1,8 @@
 # Python modules
 import json
 import logging
+import os
+from datetime import datetime, timedelta
 
 # Payload modules
 from const import *
@@ -20,7 +22,7 @@ RETRY_BACKOFF_MULTIPLIER = 2
 class syslogProviderInstance(ProviderInstance):
 
     # To store a list of hostnames that the collector VM is receiving syslogs from
-    hostnames = None
+    # hostnames = None
 
     def __init__(self,
                 tracer: logging.Logger,
@@ -47,18 +49,20 @@ class syslogProviderInstance(ProviderInstance):
 
     # Read in hostnames from properties
     def parseProperties(self) -> bool:
-        self.hostnames = self.providerProperties.get("hostnames", None)
-        if not self.hostnames:
-            self.tracer.error("[%s] no hostnames specified" % self.fullName)
-            return False
+        # self.hostnames = self.providerProperties.get("hostnames", None)
+        # if not self.hostnames:
+        #     self.tracer.error("[%s] no hostnames specified" % self.fullName)
+        #     return False
         return True
 
 ###############################################################################
 
 class syslogProviderCheck(ProviderCheck):
 
-    # Will store timestamp, hostname, and message of most recent syslog from each hostname
+    # Stores timestamp, hostname, and message of syslogs from each hostname within a certain time limit
     lastResult = []
+    # Maintains state which consists of the most recent fetched log timestamp for each hostname
+    state = {}
 
     def __init__(self,
                 provider: ProviderInstance,
@@ -67,35 +71,63 @@ class syslogProviderCheck(ProviderCheck):
 
     # Read in syslogs from hostnames and update lastResult
     def _actionFetchSyslogs(self):
-        for hostname in self.providerInstance.hostnames:
-            logpath = "/var/log/{}/syslog.log".format(hostname)
-            currResult = None
+        # for hostname in self.providerInstance.hostnames:
+        for hostname in os.listdir("/var/log/fetched_syslogs"):
+            self.updateState(hostname)
+            # logpath = "/var/log/{}/syslog.log".format(hostname)
+            logpath = "/var/log/fetched_syslogs/{}/syslog.log".format(hostname)
+            currResult = []
+            lastLogDateTime = None
             try:
                 with open(logpath, 'r') as logfile:
-                    line = logfile.readlines()[-1]
-                    split_line = line.split(" ", 2)
-                    currResult = (split_line[0], split_line[1], split_line[2])
+                    for line in logfile:
+                        split_line = line.split(" ", 2)
+                        timestamp, name, message = split_line[0], split_line[1], split_line[2]
+                        curr_datetime = datetime.now()
+                        log_datetime = datetime.strptime(timestamp.split("+")[0], "%Y-%m-%dT%H:%M:%S")
+                        # TODO: currently testing, actual timedelta will be 1 day
+                        if curr_datetime - log_datetime < timedelta(minutes=0):
+                            if self.state[hostname]["lastTimestamp"] and log_datetime > self.state[hostname]["lastTimestamp"]:
+                                # Ensure that log line has not already been fetched and ingested into the Log Analytics workspace
+                                currResult.append((timestamp, name, message))
+                                lastLogDatetime = log_datetime
+                            elif not self.state[hostname]["lastTimestamp"]:
+                                # If lastTimestamp is None, then safe to fetch
+                                currResult.append((timestamp, name, message))
+                                lastLogDatetime = log_datetime
             except:
                 self.tracer.error("[%s] unable to read log file at: %s" % (self.fullName, logpath))
             if currResult:
                 self.lastResult.append(currResult)
+                self.state[hostname]["lastTimestamp"] = lastLogDateTime
 
     # Generate a JSON-encoded string of most recent syslog from hostnames
     # This string will be ingested into Log Analytics and Customer Analytics
     def generateJsonString(self) -> str:
         logData = []
-        for result in self.lastResult:
-            logItem = {}
-            logItem["timestamp"] = result[0]
-            logItem["hostname"] = result[1]
-            logItem["message"] = result[2]
-            logData.append(logItem)
+        for hostname_logs in self.lastResult:
+            hostnameData = []
+            for line in hostname_logs:
+                logItem = {}
+                logItem["timestamp"] = line[0]
+                logItem["hostname"] = line[1]
+                logItem["message"] = line[2]
+                hostnameData.append(logItem)
+            logData.append(hostnameData)
 
         # Convert temporary dictionary into JSON string
         try:
+            # Format of JSON String:
+            # [
+            #   [(hostname_1, datetime, message), (hostname_1, datetime, message),...],
+            #   [(hostname_2, datetime, message), (hostname_2, datetime, message),...],
+            #   [(hostname_3, datetime, message), (hostname_3, datetime, message),...],
+            #   ...
+            # ]
+
             resultJsonString = json.dumps(logData, sort_keys=True, indent=4, cls=JsonEncoder)
-            self.tracer.debug("[%s] resultJson=%s" % (self.fullName,
-                                                   str(resultJsonString)))
+            # self.tracer.debug("[%s] resultJson=%s" % (self.fullName,
+            #                                        str(resultJsonString)))
         except Exception as e:
             self.tracer.error("[%s] could not format into JSON" % (self.fullName))
 
@@ -104,5 +136,7 @@ class syslogProviderCheck(ProviderCheck):
 
         return resultJsonString
 
-    def updateState(self):
-        pass
+    def updateState(self, hostname) -> bool:
+        if hostname not in self.state:
+            self.state[hostname] = {"lastTimestamp": None}
+        return True

--- a/sapmon/payload/provider/syslog.py
+++ b/sapmon/payload/provider/syslog.py
@@ -72,10 +72,10 @@ class syslogProviderCheck(ProviderCheck):
     # Read in syslogs from hostnames and update lastResult
     def _actionFetchSyslogs(self):
         # for hostname in self.providerInstance.hostnames:
-        for hostname in os.listdir("/var/log/fetched_syslogs"):
+        for hostname in os.listdir("/var/log/forwarded_syslogs"):
             self.updateState(hostname)
             # logpath = "/var/log/{}/syslog.log".format(hostname)
-            logpath = "/var/log/fetched_syslogs/{}/syslog.log".format(hostname)
+            logpath = "/var/log/forwarded_syslogs/{}/syslog.log".format(hostname)
             currResult = []
             lastLogDateTime = None
             try:


### PR DESCRIPTION
Added/modified 3 files for a basic implementation of a syslog provider:
- sapmon/content/Syslog.json: contains a check that fetches syslog data
- sapmon/payload/helper/providerfactory.py: added support for syslog provider
- sapmon/payload/provider/syslog.py: implementation of syslogProviderInstance and syslogProviderCheck classes

Currently, the syslog provider reads in and stores the last line of syslog data from each hostname specified by the properties in the secret in the Key Vault.