### PR TITLE
Disable HANA provider SQL probe

### DIFF
--- a/sapmon/content/SapHana.json
+++ b/sapmon/content/SapHana.json
@@ -101,6 +101,7 @@
             "name": "SqlProbe",
             "description": "Probe for SAP HANA SQL connection",
             "customLog": "SapHana_SqlProbe",
+            "enabled": false,
             "frequencySecs": 60,
             "includeInCustomerAnalytics": true,
             "actions": [


### PR DESCRIPTION
Disabled HANA provider SQL probe as it is no longer used
Will keep code here incase we want to reactivate it

Tested on test SapMonitor, manually edit content file, saw SQL probe check getting skipped