### PR TITLE
Mfrei/execute soap api cleanup

### DIFF
--- a/sapmon/payload/provider/sapnetweaver.py
+++ b/sapmon/payload/provider/sapnetweaver.py
@@ -512,7 +512,6 @@ class sapNetweaverProviderInstance(ProviderInstance):
                                                                                    sapSid=self.sapSid,
                                                                                    sapHostName=hostname,
                                                                                    sapSubdomain=self.sapSubdomain,
-                                                                                   sapInstanceNr=instanceNum,
                                                                                    httpProtocol=httpProtocol,
                                                                                    httpPort=port,
                                                                                    useCache=True)
@@ -1446,7 +1445,6 @@ class sapNetweaverProviderCheck(ProviderCheck):
                                                                                sapSid=self.providerInstance.sapSid,
                                                                                sapHostName=instance['hostname'],
                                                                                sapSubdomain=self.providerInstance.sapSubdomain,
-                                                                               sapInstanceNr=instance['instanceNr'],
                                                                                httpProtocol=httpProtocol,
                                                                                httpPort=port,
                                                                                useCache=True)

--- a/sapmon/payload/provider/sapnetweaver.py
+++ b/sapmon/payload/provider/sapnetweaver.py
@@ -27,12 +27,6 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 # URL defined and previous install attempt was not successful
 MINIMUM_RFC_INSTALL_RETRY_INTERVAL = timedelta(minutes=30)
 
-# timeout to use for all SOAP WSDL fetch and other API calls
-SOAP_API_TIMEOUT_SECS = 5
-
-# soap client cache expiration, after which amount of time both successful + failed soap client instantiation attempts will be refreshed
-SOAP_CLIENT_CACHE_EXPIRATIION = timedelta(minutes=10)
-
 class sapNetweaverProviderInstance(ProviderInstance):
     # static / class variables to enforce singleton behavior around rfc sdk installation attempts across all 
     # instances of SAP Netweaver provider


### PR DESCRIPTION
Doing some full container build testing on the master branch and found issue with some cleanup that was done after the last full test pass, left behind an argument that was removed from the factory method signature.  Also removing some constants that are no longer referenced.