### PR TITLE
RFCServerTimeStamp and Suppress RFC validation

### DIFF
--- a/sapmon/payload/netweaver/metricclientfactory.py
+++ b/sapmon/payload/netweaver/metricclientfactory.py
@@ -1,7 +1,6 @@
 # Python modules
 from abc import ABC, abstractmethod, abstractproperty
-from datetime import date, datetime, timedelta
-from time import time
+from datetime import date, datetime, timedelta,timezone
 import logging
 from typing import Callable, Dict, List, Optional
 
@@ -92,9 +91,11 @@ class NetWeaverMetricClient(ABC):
     # determine appropriate query window start / end time range
     @abstractmethod
     def getQueryWindow(self, 
-                       lastRunTime: datetime,
-                       minimumRunIntervalSecs: int,
-                       logTag: str) -> tuple:
+                        lastRunTime: datetime,
+                        minimumRunIntervalSecs: int,
+                        serverTimeZone : timezone,
+                        logTag: str) -> tuple:
+
         pass
 
     # query sap instance to get current server time

--- a/sapmon/payload/netweaver/rfcclient.py
+++ b/sapmon/payload/netweaver/rfcclient.py
@@ -12,6 +12,12 @@ import pandas
 # SAP modules
 from pyrfc import Connection, ABAPApplicationError, ABAPRuntimeError, LogonError, CommunicationError
 
+from datetime import datetime as dt
+from dateutil.tz import *
+
+import pytz
+from datetime import datetime
+
 # abstract base class module
 from netweaver.metricclientfactory import NetWeaverMetricClient
 from helper.tools import JsonEncoder
@@ -65,6 +71,8 @@ SAP_TASK_TYPE_MAPPINGS = {
 #        Attempting to import this file will result in impot of pyrfc, and if any of the above are not true
 #        then the import of this file will fail (due to direct pyrfc package references).
 ######
+
+
 class NetWeaverRfcClient(NetWeaverMetricClient):
     def __init__(self,
                  tracer: logging.Logger,
@@ -88,7 +96,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
         self.sapUsername = sapUsername
         self.sapPassword = sapPassword
         self.columnFilterList = columnFilterList
-        self.tzinfo = serverTimeZone 
+        self.tzinfo = serverTimeZone
         self.sapLogonGroup = sapLogonGroup
         self.msserv = "36%s" % self.sapSysNr.zfill(2)
         self.rolesFileURL = "https://aka.ms/SAPRolesFile"
@@ -113,6 +121,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
     """
     validate that config settings and that client can establish connection
     """
+
     def validate(self) -> bool:
         return True
 
@@ -125,48 +134,58 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
     Also enforce time range logic that ensures start/end time are always the same calendar 'day',
     since that is how SAP stores SMON analysis results
     """
-    def getQueryWindow(self, 
+
+    def getQueryWindow(self,
                        lastRunServerTime: datetime,
                        minimumRunIntervalSecs: int,
+                       serverTimeZone: timezone,
                        logTag: str) -> tuple:
 
+        # add/subtract UTC diff value based on the timezone that was returned
+        hoursInValue = int(
+            serverTimeZone['UTCSIGN']+(serverTimeZone['UTCDIFF']))
         # always start with assumption that query window will work backwards from current system time
-        currentServerTime = self.getServerTime(logTag)
+        currentServerTime = self.getServerTime(
+            hoursInValue, serverTimeZone['TZONE'], logTag)
 
         # usually a query window will end with the current SAP system time and will have a
         # lookback duration of the minimum check run interval (in seconds)
-        # Since SAP requirement is that start and end time must occur on the same calendar day, 
+        # Since SAP requirement is that start and end time must occur on the same calendar day,
         # we must handle special that if default window crosses over the midnight 00:00:00 boundary
-        # we will truncate it to terminate at 11:59:59PM 
+        # we will truncate it to terminate at 11:59:59PM
         if lastRunServerTime is None:
             # if there was no previous check timestamp, then we start a new query
             # window that works backwards from the current SAP system time (by the minimum check run interval time).
-            # If that will cross the midnight boundary into the previous calendar day, 
+            # If that will cross the midnight boundary into the previous calendar day,
             # then the start time should be moved up to be 00:00:00 on the current day.
             windowEnd = currentServerTime
-            windowStart = currentServerTime - timedelta(seconds=minimumRunIntervalSecs)
-            currentMidnight = datetime.combine(currentServerTime.date(), time(0, 0, 0), tzinfo=self.tzinfo)
+            windowStart = currentServerTime - \
+                timedelta(seconds=minimumRunIntervalSecs)
+            currentMidnight = datetime.combine(
+                currentServerTime.date(), time(0, 0, 0), tzinfo=self.tzinfo)
             windowStart = max(windowStart, currentMidnight)
         else:
             # if we have a previous check timestamp to use as the start of new query window,
             # and this new query window will cross this midnight into the next day,
-            # then truncate the query window so that it terminates at 11:59:59PM on the current day. 
+            # then truncate the query window so that it terminates at 11:59:59PM on the current day.
             windowStart = lastRunServerTime + timedelta(seconds=1)
-            nextMidnight = datetime.combine(windowStart.date(), time(0, 0, 0), tzinfo=self.tzinfo) + timedelta(days=1)
-            windowEnd = min(currentServerTime, nextMidnight - timedelta(seconds=1))
+            nextMidnight = datetime.combine(windowStart.date(), time(
+                0, 0, 0), tzinfo=self.tzinfo) + timedelta(days=1)
+            windowEnd = min(currentServerTime, nextMidnight -
+                            timedelta(seconds=1))
 
         # enforce maximum query window size so that we don't attempt to fetch a huge amount of data
-        # if the system has been down for prolonged period of time.  This means that we will 
+        # if the system has been down for prolonged period of time.  This means that we will
         # never attempt to backfill metric data outside of the MAX_QUERY_LOOKBACK_WINDOW
         if ((windowEnd - windowStart) > MAX_QUERY_LOOKBACK_WINDOW):
             windowStart = windowEnd - MAX_QUERY_LOOKBACK_WINDOW
 
         self.tracer.info("[%s] getQueryWindow query window for lastRunServerTime: %s, " +
-                         "currentServerTime: %s -> [start=%s, end=%s]", 
-                         logTag, 
+                         "currentServerTime: %s -> [start=%s, end=%s]",
+                         logTag,
                          lastRunServerTime,
                          currentServerTime,
-                         windowStart, 
+                         windowStart,
                          windowEnd)
 
         return windowStart, windowEnd
@@ -175,7 +194,8 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
     fetch current sap system time stamp and apply the server timezone (if known)
     so that it be used for timezone aware comparisons against tz-aware timestamps
     """
-    def getServerTime(self,
+
+    def getServerTime(self, hoursInValue: int, timeZone: tzoffset,
                       logTag: str) -> datetime:
         self.tracer.info("[%s] executing RFC to get SAP server time", logTag)
         with self._getMessageServerConnection() as connection:
@@ -183,14 +203,30 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             timestampResult = self._rfcGetSystemTime(connection, logTag=logTag)
             systemDateTime = self._parseSystemTimeResult(timestampResult)
 
-            systemDateTime = systemDateTime.replace(tzinfo=self.tzinfo)
+            # initialize timzone offset value to tzinfo for the datetime object
+            self.tzinfo = tzoffset(timeZone, hoursInValue)
 
-            return systemDateTime
+            return systemDateTime.replace(tzinfo=self.tzinfo)
+
+    """
+    fetch  SAP Server time zone and return timezone object
+    """
+
+    def getLocalTimeZone(self,logTag: str) -> tzinfo:
+
+        with self._getMessageServerConnection() as connection:
+            self.tracer.info(
+            "[%s] executing RFC /OSP/SYSTEM_TIMEZONE", logTag)
+            rfcName = '/OSP/SYSTEM_TIMEZONE'
+            timeZoneResult = connection.call(rfcName)
+            #return timezone object with UTCDIFF and UTCTimeZone
+            return timeZoneResult['ES_TTZZ']
 
     """
     fetch all /SDF/SMON_ANALYSIS_READ metric data and return as a single json string
     """
-    def getSmonMetrics(self, 
+
+    def getSmonMetrics(self,
                        startDateTime: datetime,
                        endDateTime: datetime,
                        logTag: str) -> str:
@@ -214,6 +250,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
     """
     fetch SWNC_GET_WORKLOAD_SNAPSHOT data, calculate aggregate metrics and return as json string
     """
+
     def getSwncWorkloadMetrics(self,
                                startDateTime: datetime,
                                endDateTime: datetime,
@@ -228,13 +265,15 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             parsedResult = self._parseSwncWorkloadSnapshotResult(snapshotResult, logTag=logTag)
 
             # add additional common metric properties
-            self._decorateSwncWorkloadMetrics(parsedResult, queryWindowEnd=endDateTime)
+            self._decorateSwncWorkloadMetrics(
+                parsedResult, queryWindowEnd=endDateTime)
 
             return parsedResult
 
     """
     fetch all /SDF/GET_DUMP_LOG metric data and return as a single json string
     """
+
     def getShortDumpsMetrics(self,
                        startDateTime: datetime,
                        endDateTime: datetime,
@@ -249,12 +288,14 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             if rawResult != None and len(rawResult) > 0:
                 parsedResult = self._parseLogResults(rfcName, rawResult, logTag=logTag)
                 # add additional common metric properties
-                self._decorateMetrics('E2E_HOST', 'E2E_DATE', 'E2E_TIME', parsedResult)
+                self._decorateMetrics(
+                    'E2E_HOST', 'E2E_DATE', 'E2E_TIME', parsedResult)
             return parsedResult
 
     """
     fetch all /SDF/GET_SYS_LOG metric data and return as a single json string
     """
+
     def getSysLogMetrics(self,
                        startDateTime: datetime,
                        endDateTime: datetime,
@@ -314,7 +355,8 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             snapshotResult = self._rfcGetCurrentQueuesLog(connection, rfcName, logTag=logTag)
 
             if snapshotResult != None:
-                parsedResult = self._parseQueuesAndLockSnapshotResult(rfcName, snapshotResult, "QVIEW")
+                parsedResult = self._parseQueuesAndLockSnapshotResult(
+                    rfcName, snapshotResult, "QVIEW")
                 self._decorateCurrentQueuesMetrics(parsedResult)
 
             return parsedResult
@@ -330,7 +372,8 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             snapshotResult = self._rfcGetCurrentQueuesLog(connection, rfcName, logTag=logTag)
 
             if snapshotResult != None:
-                parsedResult = self._parseQueuesAndLockSnapshotResult(rfcName, snapshotResult, "QVIEW")
+                parsedResult = self._parseQueuesAndLockSnapshotResult(
+                    rfcName, snapshotResult, "QVIEW")
                 self._decorateCurrentQueuesMetrics(parsedResult)
 
             return parsedResult
@@ -346,7 +389,8 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             snapshotResult = self._rfcReadEnqueueLog(connection, logTag=logTag)
 
             if snapshotResult != None:
-                parsedResult = self._parseQueuesAndLockSnapshotResult(rfcName, snapshotResult, "ENQ")
+                parsedResult = self._parseQueuesAndLockSnapshotResult(
+                    rfcName, snapshotResult, "ENQ")
                 self._decorateLockMetrics(parsedResult)
 
             return parsedResult
@@ -357,29 +401,31 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
     """
     create fully qualified hostname if subdomain was provided
     """
+
     def _getFullyQualifiedDomainName(self) -> str:
         if self.sapSubdomain:
             return self.sapHostName + "." + self.sapSubdomain
         else:
             return self.sapHostName
-    
+
     """
     establish rfc message server connection to sap.
     """
+
     def _getMessageServerConnection(self) -> Connection:
         # Direct application server logon:  ashost, sysnr
         # load balancing logon:  mshost, msserv, sysid, group
-        connection = Connection(#ashost=self.fqdn, 
-                                sysnr=self.sapSysNr, 
-                                mshost=self.fqdn,
-                                Group=self.sapLogonGroup,
-                                msserv=self.msserv,
-                                ssid=self.sapSid,
-                                client=self.sapClient, 
-                                user=self.sapUsername, 
-                                passwd=self.sapPassword)
+        connection = Connection(  # ashost=self.fqdn,
+            sysnr=self.sapSysNr,
+            mshost=self.fqdn,
+            Group=self.sapLogonGroup,
+            msserv=self.msserv,
+            ssid=self.sapSid,
+            client=self.sapClient,
+            user=self.sapUsername,
+            passwd=self.sapPassword)
         return connection
-            
+
     """
     establish rfc connection to sap.
     """
@@ -387,10 +433,10 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
         try:
             # Direct application server logon:  ashost, sysnr
             # load balancing logon:  mshost, msserv, sysid, group
-            connection = Connection(ashost=self.fqdn, 
-                                    sysnr=self.sapSysNr, 
-                                    client=self.sapClient, 
-                                    user=self.sapUsername, 
+            connection = Connection(ashost=self.fqdn,
+                                    sysnr=self.sapSysNr,
+                                    client=self.sapClient,
+                                    user=self.sapUsername,
                                     passwd=self.sapPassword)
             return connection
         except CommunicationError as e:
@@ -430,22 +476,28 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
     The RFC res[pmse will not have any timezone identifier, so we will apply the known
     server time zone provided by the caller when the client was created
     """
+
     def _parseSystemTimeResult(self, result: Dict[str, str]) -> datetime:
         if result is None:
-            raise ValueError("Invalid result received from BDL_GET_CENTRAL_TIMESTAMP")
+            raise ValueError(
+                "Invalid result received from BDL_GET_CENTRAL_TIMESTAMP")
 
         currentSystemDate: date = None
         currentSystemTime: time = None
 
         if 'TAG' in result:
-            currentSystemDate = datetime.strptime(result['TAG'], '%Y%m%d').date()
+            currentSystemDate = datetime.strptime(
+                result['TAG'], '%Y%m%d').date()
         else:
-            raise ValueError("RFC BDL_GET_CENTRAL_TIMESTAMP result does not have TAG value: %s" % result)
+            raise ValueError(
+                "RFC BDL_GET_CENTRAL_TIMESTAMP result does not have TAG value: %s" % result)
 
         if 'UHRZEIT' in result:
-            currentSystemTime = datetime.strptime(result['UHRZEIT'], '%H%M%S').time()
+            currentSystemTime = datetime.strptime(
+                result['UHRZEIT'], '%H%M%S').time()
         else:
-            raise ValueError("RFC BDL_GET_CENTRAL_TIMESTAMP result does not have UHRZEIT value: %s" % result)
+            raise ValueError(
+                "RFC BDL_GET_CENTRAL_TIMESTAMP result does not have UHRZEIT value: %s" % result)
 
         return datetime.combine(date=currentSystemDate, time=currentSystemTime, tzinfo=self.tzinfo)
 
@@ -453,13 +505,19 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
     helper to take seperate server Date and Time fields and return a datetime
     object with server timezone applied
     """
+
     def _datetimeFromDateAndTimeString(self, dateStr: str, timeStr: str) -> datetime:
         # expecte dateStr to have format %Y%m%d
         # expect timeStr to have format %H%M%S
-        parsedDateTime = datetime.strptime(dateStr + ' ' + timeStr, '%Y%m%d %H%M%S')
+        parsedDateTime = datetime.strptime(
+            dateStr + ' ' + timeStr, '%Y%m%d %H%M%S')
         parsedDateTime = parsedDateTime.replace(tzinfo=self.tzinfo)
 
-        return parsedDateTime
+        # apply the timezone offset to sap server time and represent in UTC
+        parsedServerTime = parsedDateTime.now(self.tzinfo)
+        parsedServerTime = parsedServerTime.astimezone(pytz.utc)
+
+        return parsedServerTime
 
     #####
     # private methods to perform two-phase call to first fetch most recent SMON run analysis identifier (guid)
@@ -485,7 +543,8 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                          endDateTime.date())
 
         try:
-            smon_result = connection.call(rfcName, FROM_DATE=startDateTime.date(), TO_DATE=endDateTime.date())
+            smon_result = connection.call(
+                rfcName, FROM_DATE=startDateTime.date(), TO_DATE=endDateTime.date())
             return smon_result
         except CommunicationError as e:
             self.tracer.error("[%s] communication error for rfc %s with hostname: %s (%s)",
@@ -499,6 +558,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
     """
     parse result from /SDF/SMON_GET_SMON_RUNS and return Run ID GUID.
     """
+
     def _parseSmonRunIdsResult(self, result):
         if 'SMON_RUNS' in result:
             if (len(result['SMON_RUNS']) == 0):
@@ -506,9 +566,11 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             if 'GUID' in result['SMON_RUNS'][0]:
                 return result['SMON_RUNS'][0]['GUID']
             else:
-                raise ValueError("GUID value does not exist in /SDF/SMON_GET_SMON_RUNS return result.")
+                raise ValueError(
+                    "GUID value does not exist in /SDF/SMON_GET_SMON_RUNS return result.")
         else:
-            raise ValueError("SMON_RUNS value does not exist in /SDF/SMON_GET_SMON_RUNS return result.")
+            raise ValueError(
+                "SMON_RUNS value does not exist in /SDF/SMON_GET_SMON_RUNS return result.")
 
     """
     call RFC SDF/SMON_ANALYSIS_RUN to lookup analysis results for specific Run ID and return the result
@@ -543,10 +605,10 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                          endDateTime.time())
 
         try:
-            result = connection.call(rfcName, 
-                                     GUID=guid, 
-                                     DATUM=startDateTime.date(), 
-                                     START_TIME=startDateTime.time(), 
+            result = connection.call(rfcName,
+                                     GUID=guid,
+                                     DATUM=startDateTime.date(),
+                                     START_TIME=startDateTime.time(),
                                      END_TIME=endDateTime.time())
             return result
         except CommunicationError as e:
@@ -564,7 +626,8 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
     def _parseSmonAnalysisResults(self, result, logTag: str):
         rfcName = 'SDF/SMON_ANALYSIS_READ'
         if result is None:
-            raise ValueError("empty result received for rfc %s for hostname: %s" % (rfcName, self.sapHostName))
+            raise ValueError("empty result received for rfc %s for hostname: %s" % (
+                rfcName, self.sapHostName))
 
         processedResult = None
         if 'HEADER' in result:
@@ -577,11 +640,13 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             if self.columnFilterList:
                 filteredResult = list()
                 for record in processedResult:
-                    filteredRow = { columnName: record[columnName] for columnName in self.columnFilterList }
+                    filteredRow = {columnName: record[columnName]
+                                   for columnName in self.columnFilterList}
                     filteredResult.append(filteredRow)
                 processedResult = filteredResult
         else:
-            raise ValueError("%s result does not contain HEADER key from hostname: %s" % (rfcName, self.sapHostName))
+            raise ValueError("%s result does not contain HEADER key from hostname: %s" % (
+                rfcName, self.sapHostName))
 
         return processedResult
 
@@ -592,8 +657,9 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
     """
     call RFC SWNC_GET_WORKLOAD_SNAPSHOT and return result records
     """
-    def _rfcGetSwncWorkloadSnapshot(self, 
-                                    connection: Connection, 
+
+    def _rfcGetSwncWorkloadSnapshot(self,
+                                    connection: Connection,
                                     startDateTime: datetime,
                                     endDateTime: datetime,
                                     logTag: str):
@@ -610,10 +676,10 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                          endDateTime.time())
 
         try:
-            swnc_result = connection.call(rfcName, 
-                                          READ_START_DATE=startDateTime.date(), 
-                                          READ_START_TIME=startDateTime.time(), 
-                                          READ_END_DATE=endDateTime.date(), 
+            swnc_result = connection.call(rfcName,
+                                          READ_START_DATE=startDateTime.date(),
+                                          READ_START_TIME=startDateTime.time(),
+                                          READ_END_DATE=endDateTime.date(),
                                           READ_END_TIME=endDateTime.time())
             return swnc_result
         except CommunicationError as e:
@@ -625,10 +691,9 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
 
         return None
 
-    
     """
     check for empty results from RFC calls
-    records is a list of records in TASKTIMES  
+    records is a list of records in TASKTIMES
     server_result_records is a list of errors in SERVER_RECS_RETURN_ERRORS
     TASKTIMES and SERVER_RECS_RETURN_ERRORS are part of result from RFC call
     """
@@ -641,7 +706,6 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             return True
         return False
 
-
     """
     parse results from SWNC_GET_WORKLOAD_SNAPSHOT and enrich with additional calculated ST03 properties
     """
@@ -650,15 +714,16 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
         if result is None:
             raise ValueError("empty result received for rfc %s from hostname: %s"
                              % (rfcName, self.sapHostName))
-        
+
         def GetKeyValue(dictionary, key):
             if key not in dictionary:
-                raise ValueError("Result received for rfc %s from hostname: %s does not contain key: %s" 
+                raise ValueError("Result received for rfc %s from hostname: %s does not contain key: %s"
                                  % (rfcName, self.sapHostName, key))
             return dictionary[key]
 
         records = GetKeyValue(result, 'TASKTIMES')
-        server_result_records = GetKeyValue(result, 'SERVER_RECS_RETURN_ERRORS')
+        server_result_records = GetKeyValue(
+            result, 'SERVER_RECS_RETURN_ERRORS')
         processed_results = list()
 
         if self._isRFCRecordEmpty(rfcName, records, server_result_records, logTag=logTag):
@@ -668,9 +733,9 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             # try to map task type hex code to more descriptive task name to make more readable, but
             # if we can't find a mapping then just echo the taskTypeId
             taskTypeId = GetKeyValue(record, 'TASKTYPE')
-            taskTypeText = (SAP_TASK_TYPE_MAPPINGS[taskTypeId] 
-                                if taskTypeId in SAP_TASK_TYPE_MAPPINGS 
-                                else taskTypeId)
+            taskTypeText = (SAP_TASK_TYPE_MAPPINGS[taskTypeId]
+                            if taskTypeId in SAP_TASK_TYPE_MAPPINGS
+                            else taskTypeId)
 
             processed_result = {
                 "Task Type": taskTypeId,
@@ -700,69 +765,85 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
 
             # ST03 - Average response time across all steps
             if (GetKeyValue(record, 'COUNT') != 0):
-                processed_result['ST03_Avg_Resp_Time'] = GetKeyValue(record, 'RESPTI') / GetKeyValue(record, 'COUNT')
+                processed_result['ST03_Avg_Resp_Time'] = GetKeyValue(
+                    record, 'RESPTI') / GetKeyValue(record, 'COUNT')
             else:
                 processed_result['ST03_Avg_Resp_Time'] = 0.0
 
             # ST03 - CPU Time, Processing Time, Queue, Roll Wait and DB times as % of Response Time
             if (GetKeyValue(record, 'RESPTI') != 0):
-                processed_result['ST03_CPU_Time'] = GetKeyValue(record, 'CPUTI') / GetKeyValue(record, 'RESPTI')
-                processed_result['ST03_Processing_Time'] = GetKeyValue(record, 'PROCTI') / GetKeyValue(record, 'RESPTI')
-                processed_result['ST03_DB_Time'] = processed_result['Total DB Time'] / GetKeyValue(record, 'RESPTI')
-                processed_result['ST03_Queue_Time'] = GetKeyValue(record, 'QUEUETI') / GetKeyValue(record, 'RESPTI')
-                processed_result['ST03_RollWait_Time'] = GetKeyValue(record, 'ROLLWAITTI') / GetKeyValue(record, 'RESPTI')
+                processed_result['ST03_CPU_Time'] = GetKeyValue(
+                    record, 'CPUTI') / GetKeyValue(record, 'RESPTI')
+                processed_result['ST03_Processing_Time'] = GetKeyValue(
+                    record, 'PROCTI') / GetKeyValue(record, 'RESPTI')
+                processed_result['ST03_DB_Time'] = processed_result['Total DB Time'] / \
+                    GetKeyValue(record, 'RESPTI')
+                processed_result['ST03_Queue_Time'] = GetKeyValue(
+                    record, 'QUEUETI') / GetKeyValue(record, 'RESPTI')
+                processed_result['ST03_RollWait_Time'] = GetKeyValue(
+                    record, 'ROLLWAITTI') / GetKeyValue(record, 'RESPTI')
             else:
                 processed_result['ST03_CPU_Time'] = 0.0
                 processed_result['ST03_Processing_Time'] = 0.0
                 processed_result['ST03_DB_Time'] = 0.0
                 processed_result['ST03_Queue_Time'] = 0.0
                 processed_result['ST03_RollWait_Time'] = 0.0
-            
+
             # ST03 - Average DB direct read latency
             if (GetKeyValue(record, 'READDIRCNT') != 0):
-                processed_result['ST03_Avg_DB_Dir_Time'] = GetKeyValue(record, 'READDIRTI') / GetKeyValue(record, 'READDIRCNT')
+                processed_result['ST03_Avg_DB_Dir_Time'] = GetKeyValue(
+                    record, 'READDIRTI') / GetKeyValue(record, 'READDIRCNT')
             else:
                 processed_result['ST03_Avg_DB_Dir_Time'] = 0.0
 
             # ST03 - Average DB sequential read latency
             if (GetKeyValue(record, 'READSEQCNT') != 0):
-                processed_result['ST03_Avg_DB_Seq_Time'] = GetKeyValue(record, 'READSEQTI') / GetKeyValue(record, 'READSEQCNT')
+                processed_result['ST03_Avg_DB_Seq_Time'] = GetKeyValue(
+                    record, 'READSEQTI') / GetKeyValue(record, 'READSEQCNT')
             else:
                 processed_result['ST03_Avg_DB_Seq_Time'] = 0.0
 
             # ST03 - Average DB change latency
             if (GetKeyValue(record, 'CHNGCNT') != 0):
-                processed_result['ST03_Avg_DB_Change_Time'] = GetKeyValue(record, 'CHNGTI') / GetKeyValue(record, 'CHNGCNT')
+                processed_result['ST03_Avg_DB_Change_Time'] = GetKeyValue(
+                    record, 'CHNGTI') / GetKeyValue(record, 'CHNGCNT')
             else:
                 processed_result['ST03_Avg_DB_Change_Time'] = 0.0
-        
+
             # ST03 - Average DB Procedure latency
             if (GetKeyValue(record, 'DBP_COUNT') != 0):
-                processed_result['ST03_Avg_DB_Procedure_Time'] = GetKeyValue(record, 'DBP_TIME') / GetKeyValue(record, 'DBP_COUNT')
+                processed_result['ST03_Avg_DB_Procedure_Time'] = GetKeyValue(
+                    record, 'DBP_TIME') / GetKeyValue(record, 'DBP_COUNT')
             else:
                 processed_result['ST03_Avg_DB_Procedure_Time'] = 0.0
-            
+
             processed_results.append(processed_result)
 
         return processed_results
 
     """
-    take parsed SWNC result set and decorate each record with additional fixed set of 
+    take parsed SWNC result set and decorate each record with additional fixed set of
     properties needed for metrics records
     """
+
     def _decorateSwncWorkloadMetrics(self, records: list, queryWindowEnd: datetime) -> None:
         currentTimestamp = datetime.now(timezone.utc)
 
         for record in records:
             # swnc workload metrics are aggregated across the SID, so no need to include hostname/instance/subdomain dimensions
             record['timestamp'] = currentTimestamp
-            record['serverTimestamp'] = queryWindowEnd
+            # apply timezone and offset to utc
+            queryWindowEndServerTime = queryWindowEnd.now(self.tzinfo)
+            queryWindowEndServerTime = queryWindowEndServerTime.astimezone(
+                pytz.utc)
+            record['serverTimestamp'] = queryWindowEndServerTime
             record['SID'] = self.sapSid
             record['client'] = self.sapClient
 
     """
     make common RFC call for GET_DUMP_LOG & GET_SYS_LOG and return result records
     """
+
     def _rfcCallToFetchLog(self,
                           rfcName: str,
                           connection: Connection,
@@ -783,10 +864,10 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                          endDateTime.time())
         try:
             rfc_call_result = connection.call(rfcName,
-                                                DATE_FROM=startDateTime.date(),
-                                                TIME_FROM=startDateTime.time(),
-                                                DATE_TO=endDateTime.date(),
-                                                TIME_TO=endDateTime.time())
+                                              DATE_FROM=startDateTime.date(),
+                                              TIME_FROM=startDateTime.time(),
+                                              DATE_TO=endDateTime.date(),
+                                              TIME_TO=endDateTime.time())
 
             return rfc_call_result
         except CommunicationError as e:
@@ -807,13 +888,14 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                               logTag, rfcName, self.sapHostName, e, exc_info=True)
 
         return None
-    
+
     """
     common method to return header information from /SDF/GET_DUMP_LOG and /SDF/GET_SYS_LOG
     """
     def _parseLogResults(self, rfcName, result, logTag):
         if result is None:
-            raise ValueError("empty result received for rfc %s for hostname: %s" % (rfcName, self.sapHostName))
+            raise ValueError("empty result received for rfc %s for hostname: %s" % (
+                rfcName, self.sapHostName))
         colNames = None
         processedResult = None
         if 'ES_E2E_LOG_STRUCT_DESC' in result:
@@ -822,59 +904,64 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             self.tracer.info("[%s] rfc %s returned %d records from hostname: %s",
                              logTag, rfcName, len(colNames), self.sapHostName)
         else:
-            raise ValueError("%s result does not contain ES_E2E_LOG_STRUCT_DESC key from hostname: %s" % (rfcName, self.sapHostName))
-    
+            raise ValueError("%s result does not contain ES_E2E_LOG_STRUCT_DESC key from hostname: %s" % (
+                rfcName, self.sapHostName))
+
         if 'ET_E2E_LOG' in result:
             # create new dictionary with only values from filterList if filter dictionary exists.
             processedResult = result['ET_E2E_LOG']
             self.tracer.info("[%s] rfc %s returned %d records from hostname: %s",
                              logTag, rfcName, len(processedResult), self.sapHostName)
         else:
-            raise ValueError("%s result does not contain ET_E2E_LOG key from hostname: %s" % (rfcName, self.sapHostName))
+            raise ValueError("%s result does not contain ET_E2E_LOG key from hostname: %s" % (
+                rfcName, self.sapHostName))
 
         processedResult = self._renameColumnNames(processedResult, colNames)
         return processedResult
 
-
     """
-    common method for RFC calls /SDF/GET_DUMP_LOG and /SDF/GET_SYS_LOG to rename the column name with meaningful 
+    common method for RFC calls /SDF/GET_DUMP_LOG and /SDF/GET_SYS_LOG to rename the column name with meaningful
     name returned by SAP in a different table
     """
+
     def _renameColumnNames(self, records: list, colNames) -> list:
-       dataframe = DataFrame (records,columns=['E2E_DATE','E2E_TIME','E2E_USER','E2E_SEVERITY','E2E_HOST',
-                                        'FIELD1','FIELD2','FIELD3','FIELD4','FIELD5','FIELD6','FIELD7',
-                                        'FIELD8','FIELD9'])
-       dataframe.rename(columns = {"FIELD1": colNames["FIELD1"],
-                            "FIELD2": colNames["FIELD2"],
-                            "FIELD3": colNames["FIELD3"],
-                            "FIELD4": colNames["FIELD4"],
-                            "FIELD5": colNames["FIELD5"],
-                            "FIELD6": colNames["FIELD6"],
-                            "FIELD7": colNames["FIELD7"],
-                            "FIELD8": colNames["FIELD8"],
-                            "FIELD9": colNames["FIELD9"]},
-                             inplace=True, errors='raise')
-       return dataframe.to_dict('records')
+        dataframe = DataFrame(records, columns=['E2E_DATE', 'E2E_TIME', 'E2E_USER', 'E2E_SEVERITY', 'E2E_HOST',
+                                         'FIELD1', 'FIELD2', 'FIELD3', 'FIELD4', 'FIELD5', 'FIELD6', 'FIELD7',
+                                                 'FIELD8', 'FIELD9'])
+        dataframe.rename(columns={"FIELD1": colNames["FIELD1"],
+                                  "FIELD2": colNames["FIELD2"],
+                                  "FIELD3": colNames["FIELD3"],
+                                  "FIELD4": colNames["FIELD4"],
+                                  "FIELD5": colNames["FIELD5"],
+                                    "FIELD6": colNames["FIELD6"],
+                                    "FIELD7": colNames["FIELD7"],
+                                    "FIELD8": colNames["FIELD8"],
+                                    "FIELD9": colNames["FIELD9"]},
+                         inplace=True, errors='raise')
+        return dataframe.to_dict('records')
 
     """
-    common method take parsed result set and decorate each record with additional fixed set of 
+    common method take parsed result set and decorate each record with additional fixed set of
     properties expected for metrics records
     """
+
     def _decorateMetrics(self, tableName, dateCol, timeCol, records: list) -> None:
         currentTimestamp = datetime.now(timezone.utc)
 
         # "dateCol": column name with date value - E.g : "20210329",
         # "timeCol": column name with time value - E.g : "121703",
         # "tableName":  column name with value similar to "sapsbx00_MSX_30"
-        
-        # regex to extract hostname / SID / instance from SERVER property, since 
-        # every short dump analysis record will contain host/instances across the 
+
+        # regex to extract hostname / SID / instance from SERVER property, since
+        # every short dump analysis record will contain host/instances across the
         # entire SAP landscape
-        serverRegex = re.compile(r"(?P<hostname>.+?)_(?P<SID>[^_]+)_(?P<instanceNr>[0-9]+)")
+        serverRegex = re.compile(
+            r"(?P<hostname>.+?)_(?P<SID>[^_]+)_(?P<instanceNr>[0-9]+)")
 
         for record in records:
             # parse DATUM/TIME fields into serverTimestamp
-            record['serverTimestamp'] = self._datetimeFromDateAndTimeString(record[dateCol], record[timeCol])
+            record['serverTimestamp'] = self._datetimeFromDateAndTimeString(
+                record[dateCol], record[timeCol])
 
             # parse SERVER field into hostname/SID/InstanceNr properties
             m = serverRegex.match(record[tableName])
@@ -884,7 +971,8 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                 record['SID'] = fields['SID']
                 record['instanceNr'] = fields['instanceNr']
             else:
-                self.tracer.error("[%s] record had unexpected SERVER format: %s", record[tableName])
+                self.tracer.error(
+                    "[%s] record had unexpected SERVER format: %s", record[tableName])
                 record['hostname'] = ''
                 record['SID'] = ''
                 record['instanceNr'] = ''
@@ -892,7 +980,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             record['client'] = self.sapClient
             record['subdomain'] = self.sapSubdomain
             record['timestamp'] = currentTimestamp
-    
+
     """
     method take parsed result set for batch jobs and decorate each record with additional fixed set of 
     properties expected for metrics records
@@ -954,22 +1042,25 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
     method take parsed result set for failedupdates and decorate each record with additional fixed set of 
     properties expected for metrics records
     """
+
     def _decorateFailedUpdatesMetrics(self, records: list) -> None:
-        currentTimestamp = datetime.now(timezone.utc)       
-        # regex to extract hostname / SID / instance from SERVER property, since 
-        # every short dump analysis record will contain host/instances across the 
+        currentTimestamp = datetime.now(timezone.utc)
+        # regex to extract hostname / SID / instance from SERVER property, since
+        # every short dump analysis record will contain host/instances across the
         # entire SAP landscape
-        serverRegex = re.compile(r"(?P<hostname>.+?)_(?P<SID>[^_]+)_(?P<instanceNr>[0-9]+)")
+        serverRegex = re.compile(
+            r"(?P<hostname>.+?)_(?P<SID>[^_]+)_(?P<instanceNr>[0-9]+)")
 
         for record in records:
             # record['VBDATE'] contains date and time value combined in one string
             # below code is used to extract the first 8 char for date and rest for time
-            if record['VBDATE'] != None and len(record['VBDATE']) > 0 :
+            if record['VBDATE'] != None and len(record['VBDATE']) > 0:
                 startdate = record['VBDATE'][0:8]
                 enddate = record['VBDATE'][8:len(record['VBDATE'])]
-            
+
             # parse DATUM/TIME fields into serverTimestamp
-            record['serverTimestamp'] = self._datetimeFromDateAndTimeString(startdate, enddate)
+            record['serverTimestamp'] = self._datetimeFromDateAndTimeString(
+                startdate, enddate)
 
             # parse SERVER field into hostname/SID/InstanceNr properties
             m = serverRegex.match(record['VBCLINAME'])
@@ -979,7 +1070,8 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                 record['SID'] = fields['SID']
                 record['instanceNr'] = fields['instanceNr']
             else:
-                self.tracer.error("[%s] record had unexpected SERVER format: %s", record['VBCLINAME'])
+                self.tracer.error(
+                    "[%s] record had unexpected SERVER format: %s", record['VBCLINAME'])
                 record['hostname'] = ''
                 record['SID'] = ''
                 record['instanceNr'] = ''
@@ -988,7 +1080,6 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             record['subdomain'] = self.sapSubdomain
             record['timestamp'] = currentTimestamp
 
-    
     """
     call RFC RFC_READ_TABLE and return result records
     """
@@ -1002,8 +1093,8 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
 
         try:
             faileupdates_result = connection.call(rfcName,
-                                                  QUERY_TABLE = 'VBHDR',
-                                                  DELIMITER = ';')
+                                                  QUERY_TABLE='VBHDR',
+                                                  DELIMITER=';')
             return faileupdates_result
         except CommunicationError as e:
             self.tracer.error("[%s] communication error for rfc %s with hostname: %s (%s)",
@@ -1037,10 +1128,10 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
         if result is None:
             raise ValueError("empty result received for rfc %s from hostname: %s"
                              % (rfcName, self.sapHostName))
-        
+
         def GetKeyValue(dictionary, key):
             if key not in dictionary:
-                raise ValueError("Result received for rfc %s from hostname: %s does not contain key: %s" 
+                raise ValueError("Result received for rfc %s from hostname: %s does not contain key: %s"
                                  % (rfcName, self.sapHostName, key))
             return dictionary[key]
 
@@ -1049,12 +1140,13 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
         if 'FIELDS' in result:
             # create new dictionary with only values from filterList if filter dictionary exists.
             records = GetKeyValue(result, 'FIELDS')
-            colNames = [ sub['FIELDNAME'] for sub in records]
+            colNames = [sub['FIELDNAME'] for sub in records]
             self.tracer.info("[%s] rfc %s returned %d records from hostname: %s",
                              logTag, rfcName, len(colNames), self.sapHostName)
         else:
-            raise ValueError("%s result does not contain FIELDS key from hostname: %s" % (rfcName, self.sapHostName))
-    
+            raise ValueError("%s result does not contain FIELDS key from hostname: %s" % (
+                rfcName, self.sapHostName))
+
         if 'DATA' in result:
             # create new dictionary with only values from filterList if filter dictionary exists.
             dataResult = result['DATA']
@@ -1062,13 +1154,15 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                              logTag, rfcName, len(dataResult), self.sapHostName)
             processedResult = self._processDataResults(dataResult, colNames)
         else:
-            raise ValueError("%s result does not contain DATA key from hostname: %s" % (rfcName, self.sapHostName))        
+            raise ValueError("%s result does not contain DATA key from hostname: %s" % (
+                rfcName, self.sapHostName))
         return processedResult
 
     """
     Function to parse the raw data result we get back into SAP and extract the column values mapping to the FEILDS table
     Sample Raw Result : "{'WA': '3DA7EF6910480030E00611BB5179B775;001;'}"
     """
+
     def _processDataResults(self, result, colNames):
         processedDataList = list()
         processedResult = None
@@ -1079,19 +1173,22 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                 processedResult = str(record).split(":")
                 if processedResult != None and len(processedResult) > 0:
                     # Remove additional characters e.g {, }, '
-                    processedResult = processedResult[1].replace("'","").replace("}","")
+                    processedResult = processedResult[1].replace(
+                        "'", "").replace("}", "")
                     # Remove the empty characters in the string using strip function and then split the string to
                     # extract each value as a different column value
-                    processedResult = [x.strip() for x in processedResult.split(';')]
+                    processedResult = [x.strip()
+                                       for x in processedResult.split(';')]
                     # colNames - contains the name of the key and processedResult contains the values
                     # failedUpdateDic - dict with key and values
                     failedUpdateDic = dict(zip(colNames, processedResult))
                     processedDataList.append(failedUpdateDic)
         return processedDataList
-    
+
     """
     RFC call for BAPI_XBP_JOB_SELECT and return result records
     """
+
     def _rfcGetBatchJob(self,
                         connection: Connection,
                         startDateTime: datetime,
@@ -1112,8 +1209,8 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             self._rfcCallLogonJob(connection, logTag=logTag)
 
             rfc_call_result = connection.call(rfcName,
-                                              EXTERNAL_USER_NAME = self.sapUsername,
-                                              JOB_SELECT_PARAM = jobSelectParam)
+                                              EXTERNAL_USER_NAME=self.sapUsername,
+                                              JOB_SELECT_PARAM=jobSelectParam)
 
             return rfc_call_result
         except CommunicationError as e:
@@ -1131,6 +1228,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
     """
     RFC call for BAPI_XMI_LOGON and return result records
     """
+
     def _rfcCallLogonJob(self,
                         connection: Connection,
                         logTag: str):
@@ -1139,13 +1237,13 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                          logTag,
                          rfcName,
                          self.sapHostName)
-        
+
         try:
             rfc_call_result = connection.call(rfcName,
-                                              EXTCOMPANY = 'TESTC',
-                                              EXTPRODUCT = 'TESTP',
-                                              INTERFACE = 'XBP',
-                                              VERSION = '3.0')
+                                              EXTCOMPANY='TESTC',
+                                              EXTPRODUCT='TESTP',
+                                              INTERFACE='XBP',
+                                              VERSION='3.0')
 
             return rfc_call_result
         except CommunicationError as e:
@@ -1167,7 +1265,8 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
     def _parseBatchJobResult(self, result, logTag):
         rfcName = 'BAPI_XBP_JOB_SELECT'
         if result is None:
-            raise ValueError("empty result received for rfc %s for hostname: %s" % (rfcName, self.sapHostName))
+            raise ValueError("empty result received for rfc %s for hostname: %s" % (
+                rfcName, self.sapHostName))
 
         processedResult = None
         if 'JOB_HEAD' in result:
@@ -1176,7 +1275,8 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
             self.tracer.info("[%s] rfc %s returned %d records from hostname: %s",
                              logTag, rfcName, len(processedResult), self.sapHostName)           
         else:
-            raise ValueError("%s result does not contain JOB_HEAD key from hostname: %s" % (rfcName, self.sapHostName))
+            raise ValueError("%s result does not contain JOB_HEAD key from hostname: %s" % (
+                rfcName, self.sapHostName))
 
         return processedResult
 
@@ -1208,9 +1308,10 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
         return None
 
     """
-    parse results from ENQUEUE_READ/TRFC_QIN_GET_CURRENT_QUEUES/TRFC_QOUT_GET_CURRENT_QUEUES 
+    parse results from ENQUEUE_READ/TRFC_QIN_GET_CURRENT_QUEUES/TRFC_QOUT_GET_CURRENT_QUEUES
     and enrich with additional properties
     """
+
     def _parseQueuesAndLockSnapshotResult(self, rfcName, result, tableName):
         if result is None:
             raise ValueError("empty result received for rfc %s from hostname: %s"
@@ -1225,6 +1326,7 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
     take parsed TRFC_QIN_GET_CURRENT_QUEUES/TRFC_QOUT_GET_CURRENT_QUEUES result set
     and decorate each record with additional fixed set of  properties needed for metrics records
     """
+
     def _decorateCurrentQueuesMetrics(self, records: list) -> None:
         for record in records:
             record['SID'] = self.sapSid
@@ -1245,8 +1347,8 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
                          self.sapClient)
 
         try:
-            lock_result = connection.call(rfcName, 
-                                          GUNAME = "*")
+            lock_result = connection.call(rfcName,
+                                          GUNAME="*")
             return lock_result
         except CommunicationError as e:
             self.tracer.error("[%s] communication error for rfc %s with hostname: %s (%s)",
@@ -1267,15 +1369,38 @@ class NetWeaverRfcClient(NetWeaverMetricClient):
         return None
 
     """
-    take parsed ENQUEUE_READ result set and decorate each record with additional fixed set of 
+    take parsed ENQUEUE_READ result set and decorate each record with additional fixed set of
     properties needed for metrics records
     """
+
     def _decorateLockMetrics(self, records: list) -> None:
+        currentTimestamp = datetime.now(timezone.utc)
+        serverRegex = re.compile(r"(?P<hostname>.+?)_(?P<SID>[^_]+)_(?P<instanceNr>[0-9]+)")
         for record in records:
+            # parse GTDATE/GTTIME fields into serverTimestamp
             record['serverTimestamp'] = self._datetimeFromDateAndTimeString(record['GTDATE'], record['GTTIME'])
-            record['SID'] = self.sapSid
-            record['instanceNr'] = record["GTSYSNR"]
-            record['hostname'] = record["GTHOST"].split(".")[0]
+            # value returned by SAP for S4HANA - 's4tsts4dci_S4D_00...............'
+            # value returned by SAP for SQL - 'SAPTSTGTMCI..................'
+            # code to give a consistent format to GTHOST for different values returned by SAP
+            # and use the regex to decorate the table with hostname, SID and InstanceNr
+            actual_hostname = record["GTHOST"].split(".")[0]
+            if(actual_hostname.find(self.sapSid) > 0) :
+                record['GTHOST'] = actual_hostname
+            else:
+                record['GTHOST'] = actual_hostname + "_" + self.sapSid + "_" + record["GTSYSNR"]
+            # parse SERVER field into hostname/SID/InstanceNr properties
+            m = serverRegex.match(record['GTHOST'])
+            if m:
+                fields = m.groupdict()
+                record['hostname'] = fields['hostname']
+                record['SID'] = fields['SID']
+                record['instanceNr'] = fields['instanceNr']
+            else:
+                self.tracer.error("[%s] record had unexpected SERVER format: %s", record['GTSYSNR'])
+                record['hostname'] = ''
+                record['SID'] = ''
+                record['instanceNr'] = ''
+
             record['client'] = self.sapClient
             record['subdomain'] = self.sapSubdomain
-            record['timestamp'] = datetime.now(timezone.utc)
+            record['timestamp'] = currentTimestamp

--- a/sapmon/payload/provider/sapnetweaver.py
+++ b/sapmon/payload/provider/sapnetweaver.py
@@ -27,6 +27,16 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 # URL defined and previous install attempt was not successful
 MINIMUM_RFC_INSTALL_RETRY_INTERVAL = timedelta(minutes=30)
 
+# timeout to use for all SOAP WSDL fetch and other API calls
+SOAP_API_TIMEOUT_SECS = 5
+
+# soap client cache expiration, after which amount of time both successful + failed soap client instantiation attempts will be refreshed
+SOAP_CLIENT_CACHE_EXPIRATIION = timedelta(minutes=10)
+
+# SAPServerTimezone cache expiration
+SERVER_TIMEZONE_CACHE_EXPIRATIION = timedelta(seconds=60)
+
+
 class sapNetweaverProviderInstance(ProviderInstance):
     # static / class variables to enforce singleton behavior around rfc sdk installation attempts across all 
     # instances of SAP Netweaver provider
@@ -56,6 +66,8 @@ class sapNetweaverProviderInstance(ProviderInstance):
 
         # cache WSDL SOAP clients so we can re-use them across checks for the same provider and cut down off-box calls
         self._soapClientCache = {}
+
+        self._timeZoneCache = {}
 
         # the RFC SDK does not allow client to specify a timeout and in fact appears to have a connection timeout of 60 secs. 
         # In cases where RFC calls timeout due to some misconfiguration, multiple retries can lead to metric gaps of several minutes.  
@@ -412,52 +424,53 @@ class sapNetweaverProviderInstance(ProviderInstance):
 
         # update logging prefix with the specific instance details of the client
         sapHostnameStr = "%s|%s" % (client.Hostname, client.InstanceNr)
+
+         # initialie timezone data for utc offset fetched from SAP server
+        serverTimeZone = (self.getRfcServerTimeZone())
         
         # get metric query window to lookback 10 minutes to see if any results are available.  If not that probably
         # indicates customer has not enabled SMON on their SAP system
         self.tracer.info("%s attempting to fetch server timestamp from %s", logTag, sapHostnameStr)
         (startTime, endTime) = client.getQueryWindow(lastRunServerTime=None, 
                                                      minimumRunIntervalSecs=600,
+                                                     serverTimeZone=serverTimeZone,
                                                      logTag=logTag)
 
-        self.tracer.info("%s attempting to fetch SMON metrics from %s", logTag, sapHostnameStr)
-        result = client.getSmonMetrics(startDateTime=startTime, endDateTime=endTime, logTag=logTag)
-        self.tracer.info("%s successfully queried SMON metrics from %s", logTag, sapHostnameStr)
+        # hard-coded list of available RFC methods that correspond to RFC metrics to validate
+        rfcMethodChecks = ['getSmonMetrics', 
+                         'getSwncWorkloadMetrics', 
+                         'getShortDumpsMetrics',
+                         'getSysLogMetrics',
+                         'getFailedUpdatesMetrics',
+                         'getBatchJobMetrics',
+                         'getInboundQueuesMetrics',
+                         'getOutboundQueuesMetrics',
+                         'getEnqueueReadMetrics'
+                         ]                                             
+        
+        rfcMethodParameterChecks = [
+                         'getFailedUpdatesMetrics',
+                         'getInboundQueuesMetrics',
+                         'getOutboundQueuesMetrics'
+                         'getEnqueueReadMetrics'
+                         ]       
 
-        self.tracer.info("%s attempting to fetch SWNC workload metrics from %s", logTag, sapHostnameStr)
-        result = client.getSwncWorkloadMetrics(startDateTime=startTime, endDateTime=endTime, logTag=logTag)
-        self.tracer.info("%s successfully queried SWNC workload metrics from %s", logTag, sapHostnameStr)
-
-        self.tracer.info("%s attempting to fetch Short Dump metrics from %s", logTag, sapHostnameStr)
-        result = client.getShortDumpsMetrics(startDateTime=startTime, endDateTime=endTime, logTag=logTag)
-        self.tracer.info("%s successfully queried Short Dump metrics from %s", logTag, sapHostnameStr)
-
-        self.tracer.info("%s attempting to fetch Sys Log metrics from %s", logTag, sapHostnameStr)
-        result = client.getSysLogMetrics(startDateTime=startTime, endDateTime=endTime, logTag=logTag)
-        self.tracer.info("%s successfully queried Sys Log metrics from %s", logTag, sapHostnameStr)
-
-        self.tracer.info("%s attempting to fetch Failed Updates metrics from %s", logTag, sapHostnameStr)
-        result = client.getFailedUpdatesMetrics(logTag=logTag)
-        self.tracer.info("%s successfully queried  Failed Updates metrics from %s", logTag, sapHostnameStr)
-
-        self.tracer.info("%s attempting to fetch Batch Job metrics from %s", logTag, sapHostnameStr)
-        result = client.getBatchJobMetrics(startDateTime=startTime, endDateTime=endTime, logTag=logTag)
-        self.tracer.info("%s successfully queried Batch Job metrics from %s", logTag, sapHostnameStr)
-
-        self.tracer.info("%s attempting to fetch inbound queue metrics from %s", logTag, sapHostnameStr)
-        result = client.getInboundQueuesMetrics(logTag=logTag)
-        self.tracer.info("%s successfully queried inbound queue metrics from %s", logTag, sapHostnameStr)
-
-        self.tracer.info("%s attempting to fetch outbound queue metrics from %s", logTag, sapHostnameStr)
-        result = client.getOutboundQueuesMetrics(logTag=logTag)
-        self.tracer.info("%s successfully queried outbound queue metrics from %s", logTag, sapHostnameStr)
-
-        self.tracer.info("%s attempting to fetch lock entries metrics from %s", logTag, sapHostnameStr)
-        result = client.getEnqueueReadMetrics(logTag=logTag)
-        self.tracer.info("%s successfully queried lock entries metrics from %s", logTag, sapHostnameStr)
-
-        self.tracer.info("%s successfully validated all known RFC SDK calls", logTag)
-
+        self.tracer.info("%s connecting to sap to validate RFC metrics", logTag)
+       
+        for rfcMetricName in rfcMethodChecks:
+            try:
+                method = getattr(client, rfcMetricName)
+                if rfcMetricName in rfcMethodParameterChecks:
+                    self.tracer.info("%s attempting to fetch %s metrics from %s", logTag, rfcMetricName,sapHostnameStr)
+                    result = method(logTag=logTag)
+                    self.tracer.info("%s successfully queried  %s metrics from %s", logTag,rfcMetricName, sapHostnameStr)
+                else:
+                    self.tracer.info("%s attempting to fetch %s metrics from %s", logTag,rfcMetricName, sapHostnameStr)
+                    result = method(startDateTime=startTime, endDateTime=endTime, logTag=logTag)
+                    self.tracer.info("%s successfully queried %s metrics from %s", logTag,rfcMetricName, sapHostnameStr)
+            except:
+                    self.tracer.error("%s suppressing errors during validation of RFC method %s ", logTag, rfcMetricName, exc_info=True)
+                   
     """
     query SAP SOAP API to return list of all instances in the SID, but if caller specifies that cached results are okay
     and we have cached instance list with the provider instance, then just return the cached results
@@ -821,7 +834,24 @@ class sapNetweaverProviderInstance(ProviderInstance):
             self.tracer.error("%s exception trying to setup and validate RFC SDK, RFC calls will be disabled: %s", self.logTag, e, exc_info=True)
 
         return False
-
+    """
+    cache timezone  value returned by RFC timezone function call and apply expiration datetime to avoid 
+    multiple RFC function calls 
+    
+    """
+    def getRfcServerTimeZone(self) :
+        logTag = "[%s][%s][ServerTimeZone]" % (self.fullName, self.sapSid)
+        if ( 'SAPServerTimeZone' in self._timeZoneCache ):
+            timeZoneCacheEntry = self._timeZoneCache['SAPServerTimeZone']
+            if(timeZoneCacheEntry['expirationDateTime'] > datetime.utcnow()):
+                if(timeZoneCacheEntry['tz']):
+                    self.tracer.info("%s Cached server timezone: ", self._timeZoneCache['SAPServerTimeZone']['expirationDateTime'])
+                    return (timeZoneCacheEntry['tz'])
+        else :
+            client = self.getRfcClient(logTag=logTag)
+            self._timeZoneCache['SAPServerTimeZone'] = { 'tz':(client.getLocalTimeZone(logTag=logTag)), 'expirationDateTime': datetime.utcnow() + SERVER_TIMEZONE_CACHE_EXPIRATIION }
+            self.tracer.info("%s Caching Server timezone at: ", self._timeZoneCache['SAPServerTimeZone']['expirationDateTime'])
+        return (self._timeZoneCache['SAPServerTimeZone']['tz'])
 
 ###########################
 class sapNetweaverProviderCheck(ProviderCheck):
@@ -991,9 +1021,13 @@ class sapNetweaverProviderCheck(ProviderCheck):
             # update logging prefix with the specific instance details of the client
             sapHostnameStr = "%s|%s" % (client.Hostname, client.InstanceNr)
             
+             # initialie timezone data for utc offset fetched from SAP server
+            serverTimeZone = (self.providerInstance.getRfcServerTimeZone())
+
             # get metric query window based on our last successful query where results were returned
             (startTime, endTime) = client.getQueryWindow(lastRunServerTime=self.lastRunServer, 
                                                          minimumRunIntervalSecs=self.frequencySecs,
+                                                         serverTimeZone =serverTimeZone,
                                                          logTag=self.logTag)
             self.lastResult = client.getSmonMetrics(startDateTime=startTime, endDateTime=endTime, logTag=self.logTag)
 
@@ -1039,9 +1073,13 @@ class sapNetweaverProviderCheck(ProviderCheck):
             # update logging prefix with the specific instance details of the client
             sapHostnameStr = "%s|%s" % (client.Hostname, client.InstanceNr)
             
+            # initialie timezone data for utc offset fetched from SAP server
+            serverTimeZone = (self.providerInstance.getRfcServerTimeZone())
+
             # get metric query window based on our last successful query where results were returned
             (startTime, endTime) = client.getQueryWindow(lastRunServerTime=self.lastRunServer, 
                                                          minimumRunIntervalSecs=self.frequencySecs,
+                                                         serverTimeZone =serverTimeZone,
                                                          logTag=self.logTag)
 
             self.lastResult = client.getSwncWorkloadMetrics(startDateTime=startTime, endDateTime=endTime, logTag=self.logTag)
@@ -1088,9 +1126,13 @@ class sapNetweaverProviderCheck(ProviderCheck):
             # update logging prefix with the specific instance details of the client
             sapHostnameStr = "%s|%s" % (client.Hostname, client.InstanceNr)
             
+             # initialie timezone data for utc offset fetched from SAP server
+            serverTimeZone = (self.providerInstance.getRfcServerTimeZone())
+
             # get metric query window based on our last successful query where results were returned
             (startTime, endTime) = client.getQueryWindow(lastRunServerTime=self.lastRunServer, 
                                                          minimumRunIntervalSecs=self.frequencySecs,
+                                                         serverTimeZone =serverTimeZone,
                                                          logTag=self.logTag)
 
             self.lastResult = client.getShortDumpsMetrics(startDateTime=startTime, endDateTime=endTime, logTag=self.logTag)
@@ -1137,9 +1179,13 @@ class sapNetweaverProviderCheck(ProviderCheck):
             # update logging prefix with the specific instance details of the client
             sapHostnameStr = "%s|%s" % (client.Hostname, client.InstanceNr)
             
+           # initialie timezone data for utc offset fetched from SAP server
+            serverTimeZone = (self.providerInstance.getRfcServerTimeZone())
+
             # get metric query window based on our last successful query where results were returned
             (startTime, endTime) = client.getQueryWindow(lastRunServerTime=self.lastRunServer, 
                                                          minimumRunIntervalSecs=self.frequencySecs,
+                                                         serverTimeZone =serverTimeZone,
                                                          logTag=self.logTag)
 
             self.lastResult = client.getSysLogMetrics(startDateTime=startTime, endDateTime=endTime, logTag=self.logTag)
@@ -1186,9 +1232,13 @@ class sapNetweaverProviderCheck(ProviderCheck):
             # update logging prefix with the specific instance details of the client
             sapHostnameStr = "%s|%s" % (client.Hostname, client.InstanceNr)
             
+            # initialie timezone data for utc offset fetched from SAP server
+            serverTimeZone = (self.providerInstance.getRfcServerTimeZone())
+
             # get metric query window based on our last successful query where results were returned
             (startTime, endTime) = client.getQueryWindow(lastRunServerTime=self.lastRunServer, 
                                                          minimumRunIntervalSecs=self.frequencySecs,
+                                                         serverTimeZone =serverTimeZone,
                                                          logTag=self.logTag)
 
             self.lastResult = client.getFailedUpdatesMetrics(logTag=self.logTag)
@@ -1235,9 +1285,13 @@ class sapNetweaverProviderCheck(ProviderCheck):
             # update logging prefix with the specific instance details of the client
             sapHostnameStr = "%s|%s" % (client.Hostname, client.InstanceNr)
             
+             # initialie timezone data for utc offset fetched from SAP server
+            serverTimeZone = (self.providerInstance.getRfcServerTimeZone())
+
             # get metric query window based on our last successful query where results were returned
             (startTime, endTime) = client.getQueryWindow(lastRunServerTime=self.lastRunServer, 
                                                          minimumRunIntervalSecs=self.frequencySecs,
+                                                         serverTimeZone =serverTimeZone,
                                                          logTag=self.logTag)
 
             self.lastResult = client.getBatchJobMetrics(startDateTime=startTime, endDateTime=endTime, logTag=self.logTag)


### PR DESCRIPTION
1. SAP ServerTimeZone for RFC calls.
   TimeZone information is fetched from RFC function(/OSP/SYSTEM_TIMEZONE) call that returns UTC difference and timezone type. This is applied to servertimezone datetime field and stored in log analytics offset to UTC.
2. RFC methods calls validation errors are suppressed to make add provider successful.
3. Changes to push common value for Host column(GTHOST) for SAP HANA and SQL

 


 