### PR TITLE
Fixed no-internet script to run docker with current version

### DIFF
--- a/no-internet/setup.sh
+++ b/no-internet/setup.sh
@@ -162,7 +162,7 @@ createPrivateEndpoint() {
         --name ${private_dns_zone_name} \
         --output none 2>/dev/null
     status=$?
-    set -e
+    
     if [ $status -ne 0 ]; then
         az network private-dns zone create \
           --resource-group ${VNET_RG} \
@@ -180,7 +180,7 @@ createPrivateEndpoint() {
         --name ${type}-${SAPMON_ID} \
         --output none 2>/dev/null
     status=$?
-    set -e
+    
     if [ $status -ne 0 ]; then
         az network private-dns link vnet create \
           --resource-group ${VNET_RG} \
@@ -218,6 +218,8 @@ az monitor private-link-scope scoped-resource create \
     --scope-name PrivateLinkScopeLAWS \
     --output none
 createPrivateEndpoint ${LAWS_PRIVATE_ENDPOINT_NAME} azuremonitor /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/sapmon-rg-${SAPMON_ID}/providers/microsoft.insights/privateLinkScopes/PrivateLinkScopeLAWS privatelink.ods.opinsights.azure.com
+
+set -e
 
 STORAGE_BLOB_PRIVATE_IP=$(
     az network private-endpoint dns-zone-group show \

--- a/no-internet/setup.sh
+++ b/no-internet/setup.sh
@@ -260,7 +260,7 @@ docker load -i azure-monitor-for-sap-solutions-${COLLECTOR_VERSION}.tar && \
 docker rm -f "'$(docker ps -aq)'" 2>/dev/null || true && \
 docker run --network host mcr.microsoft.com/oss/azure/azure-monitor-for-sap-solutions:${COLLECTOR_VERSION} python3 /var/opt/microsoft/sapmon/${COLLECTOR_VERSION}/sapmon/payload/sapmon.py onboard --logAnalyticsWorkspaceId ${WORKSPACE_ID} --logAnalyticsSharedKey ${SHARED_KEY} --enableCustomerAnalytics > /tmp/monitor.log.out && \
 mkdir -p /var/opt/microsoft/sapmon/state && \
-docker run --name sapmon-ver-${COLLECTOR_VERSION} --detach --restart always --log-opt max-size=50m --log-opt max-file=5 --network host --volume /var/opt/microsoft/sapmon/state:/var/opt/microsoft/sapmon/${COLLECTOR_VERSION}/sapmon/state --env Version=${COLLECTOR_VERSION} mcr.microsoft.com/oss/azure/azure-monitor-for-sap-solutions:${COLLECTOR_VERSION} python3 /var/opt/microsoft/sapmon/%s/sapmon/payload/sapmon.py monitor"
+docker run --name sapmon-ver-${COLLECTOR_VERSION} --detach --restart always --log-opt max-size=50m --log-opt max-file=5 --network host --volume /var/opt/microsoft/sapmon/state:/var/opt/microsoft/sapmon/${COLLECTOR_VERSION}/sapmon/state --env Version=${COLLECTOR_VERSION} mcr.microsoft.com/oss/azure/azure-monitor-for-sap-solutions:${COLLECTOR_VERSION} python3 /var/opt/microsoft/sapmon/${COLLECTOR_VERSION}/sapmon/payload/sapmon.py monitor"
 
 az vm extension set \
     --resource-group sapmon-rg-${SAPMON_ID} \


### PR DESCRIPTION
There was a bug in "no-internet" script, so not able pick the path to run correctly inside the collector VM.