### PR TITLE
changing base image from python:3.7-slim to python:3.7-slim-buster

### DIFF
--- a/Docker/master/Dockerfile
+++ b/Docker/master/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.7-slim-buster
 
 ARG RELEASE
 RUN apt-get update -y


### PR DESCRIPTION
The 3.7-slim is pointing to debian 11 now because of which its failing to create docker image.

Till last version 2.23 debian 10 was used to create docker image. So changing base image from python:3.7-slim to python:3.7-slim-buster.